### PR TITLE
args.USE_PROXYDHCP vs args.DHCP_PROXYDHCP

### DIFF
--- a/server.py
+++ b/server.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.USE_HTTP and not args.USE_IPXE:
         print "HTTP selected but iPXE disabled. PXE ROM must support HTTP requests"
-    if args.USE_PROXYDHCP:
+    if args.DHCP_PROXYDHCP:
         args.USEDHCP = True
 
     os.chdir(args.NETBOOT)


### PR DESCRIPTION
args.USE_PROXYDHCP used in one place, but DHCP_PROXYDHCP specified in argparse.
