### PR TITLE
Minor Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-##Pure Python2 PXE (DHCP/TFTP/HTTP) server.
+##Pure Python2 PXE (DHCP/TFTP/HTTP) Server
 
 Supports iPXE chainloading, and therefore iPXE scripts.
 
 Edit the server.py settings to your preferred network settings or run with --help  
 
-Core.iso is from the TinyCore Project (http://distro.ibiblio.org/tinycorelinux/)  
-chainload.kpxe is the undionly.kpxe from the iPXE project (http://ipxe.org/)  
-pxelinux.0, menu.c32 and memdisk are from the SYSLINUX project (http://www.syslinux.org/)  
+Core.iso is from the [TinyCore Project](http://distro.ibiblio.org/tinycorelinux/)  
+chainload.kpxe is the undionly.kpxe from the [iPXE Project](http://ipxe.org/)  
+pxelinux.0, menu.c32 and memdisk are from the [SYSLINUX Project](http://www.syslinux.org/)  
 
 
 Each server (TFTP/HTTP/DHCP) is in it's own class in it's own file. These can be used

--- a/netboot/pxelinux.cfg/default
+++ b/netboot/pxelinux.cfg/default
@@ -1,7 +1,7 @@
 DEFAULT menu.c32
 TIMEOUT 1
-MENU TITLE PXE
+MENU TITLE PyPXE
 
-LABEL Core
+LABEL TinyCore
 KERNEL memdisk
 APPEND iso initrd=Core.iso

--- a/server.py
+++ b/server.py
@@ -6,9 +6,7 @@ from tftpd import TFTPD
 from dhcpd import DHCPD
 if __name__ == '__main__':
     if os.getuid() != 0:
-        print
-        print "Not root. Servers will probably fail to bind"
-        print
+        print "\nWarning: Not root. Servers will probably fail to bind.\n"
     
     #PyPXE Global Settings
     NETBOOT = "netboot" #local boot file directory
@@ -59,7 +57,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     if args.USE_HTTP and not args.USE_IPXE:
-        print "HTTP selected but iPXE disabled. PXE ROM must support HTTP requests"
+        print "\nWarning: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.\n"
     if args.USE_PROXYDHCP:
         args.USEDHCP = True
 


### PR DESCRIPTION
Improved README hypertext linking

Changed label for TinyCore and PXE Menu Title in pxelinux.cfg

Removed extra print statements and added newline characters instead in
server.py as well as prefixed those statements with 'Warning:'
