### PR TITLE
Minor Bug Fix, Various Improvements

### DIFF
--- a/dhcpd.py
+++ b/dhcpd.py
@@ -22,8 +22,7 @@ class DHCPD:
         self.ipxe = useipxe
         self.proxydhcp = proxydhcp
         if usehttp and not self.ipxe:
-            print "HTTP enabled but iPXE isn't, your client MUST support"
-            print "native HTTP booting (e.g. iPXE ROM)"
+            print "\nWARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.\n"
         if useipxe and usehttp:
             self.filename = "http://%s%s" % (self.fileserver, self.filename)
         if useipxe and not usehttp:

--- a/server.py
+++ b/server.py
@@ -4,6 +4,19 @@ from httpd import HTTPD
 from tftpd import TFTPD
 from dhcpd import DHCPD
 
+#Default Network Boot File Directory
+NETBOOTDIR = 'netboot'
+
+#DHCP Default Server Settings
+DHCP_PROXYMODE = False
+DHCP_SERVER_IP = '192.168.2.2'
+DHCP_FILESERVER_IP = '192.168.2.2'
+DHCP_OFFER_BEGIN = '192.168.2.100'
+DHCP_OFFER_END = '192.168.2.150'
+DHCP_SUBNET = '255.255.255.0'
+DHCP_ROUTER = '192.168.2.1'
+DHCP_DNS = '8.8.8.8'
+
 if __name__ == '__main__':
     
     try:
@@ -11,42 +24,20 @@ if __name__ == '__main__':
         if os.getuid() != 0:
             print "\nWARNING: Not root. Servers will probably fail to bind.\n"
 
-        #PyPXE Global Settings
-        NETBOOT = "netboot" #local boot file directory
-        USE_IPXE = True #boot into ipxe first, then filename
-        USE_HTTP = True #filename is on fileserver as http
-        USE_DHCP = True #enable/disable built-in DHCP server
-
-        #DHCP Server Settings
-        DHCP_PROXYDHCP = False
-        DHCP_SERVER_IP = '192.168.2.2'
-        DHCP_FILESERVER_IP = '192.168.2.2'
-        DHCP_OFFER_BEGIN = '192.168.2.100'
-        DHCP_OFFER_END = '192.168.2.150'
-        DHCP_SUBNET = '255.255.255.0'
-        DHCP_ROUTER = '192.168.2.1'
-        DHCP_DNS = '8.8.8.8'
-
-        if not USE_IPXE:
-            DHCP_FILENAME = "/pxelinux.0"
-        elif not USE_HTTP:
-            DHCP_FILENAME = "/boot.ipxe"
-        else:
-            DHCP_FILENAME = "/boot.http.ipxe"
-
+        #define command line arguments
         parser = argparse.ArgumentParser(description="Set options at runtime. Defaults are in %(prog)s", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         exclusive = parser.add_mutually_exclusive_group(required=False)
-        exclusive.add_argument("--dhcp", action="store_true", dest="USE_DHCP", help="Use builtin DHCP server (use with --proxydhcp for proxy mode)", default=USE_DHCP)
-        exclusive.add_argument("--proxydhcp", action="store_true", dest="DHCP_PROXYDHCP", help="Use builtin DHCP server in proxy mode (implies --dhcp)", default=DHCP_PROXYDHCP)
-        exclusive.add_argument("--no-dhcp", action="store_false", dest="USE_DHCP", help="Disable builtin DHCP server", default=not USE_DHCP)
+        exclusive.add_argument("--dhcp", action="store_true", dest="USE_DHCP", help="Use builtin DHCP server (use with --proxydhcp for proxy mode)", default=True)
+        exclusive.add_argument("--proxydhcp", action="store_true", dest="DHCP_PROXYMODE", help="Use builtin DHCP server in proxy mode (implies --dhcp)", default=DHCP_PROXYMODE)
+        exclusive.add_argument("--no-dhcp", action="store_false", dest="USE_DHCP", help="Disable builtin DHCP server")
 
         exclusive = parser.add_mutually_exclusive_group(required=False)
-        exclusive.add_argument("--ipxe", action="store_true", dest="USE_IPXE", help="Chainload iPXE rom", default=USE_IPXE)
-        exclusive.add_argument("--no-ipxe", action="store_false", dest="USE_IPXE", help="Don't chainload iPXE rom", default=not USE_IPXE)
+        exclusive.add_argument("--ipxe", action="store_true", dest="USE_IPXE", help="Chainload iPXE ROM", default=True)
+        exclusive.add_argument("--no-ipxe", action="store_false", dest="USE_IPXE", help="Don't chainload iPXE ROM")
 
         exclusive = parser.add_mutually_exclusive_group(required=False)
-        exclusive.add_argument("--http", action="store_true", dest="USE_HTTP", help="Use builtin HTTP server", default=USE_HTTP)
-        exclusive.add_argument("--no-http", action="store_false", dest="USE_HTTP", help="Don't use builtin HTTP server", default=not USE_HTTP)
+        exclusive.add_argument("--http", action="store_true", dest="USE_HTTP", help="Use builtin HTTP server", default=True)
+        exclusive.add_argument("--no-http", action="store_false", dest="USE_HTTP", help="Don't use builtin HTTP server")
 
         parser.add_argument("-s", "--server", action="store", dest="DHCP_SERVER_IP", help="DHCP Server IP", default=DHCP_SERVER_IP)
         parser.add_argument("-f", "--fileserver", action="store", dest="DHCP_FILESERVER_IP", help="Fileserver IP", default=DHCP_FILESERVER_IP)
@@ -55,16 +46,30 @@ if __name__ == '__main__':
         parser.add_argument("-n", "--subnet", action="store", dest="DHCP_SUBNET", help="DHCP lease subnet", default=DHCP_SUBNET)
         parser.add_argument("-r", "--router", action="store", dest="DHCP_ROUTER", help="DHCP lease router", default=DHCP_ROUTER)
         parser.add_argument("-d", "--dns", action="store", dest="DHCP_DNS", help="DHCP lease DNS server", default=DHCP_DNS)
-        parser.add_argument("-a", "--netboot", action="store", dest="NETBOOT", help="File serve directory", default=NETBOOT)
-        parser.add_argument("-i", "--filename", action="store", dest="DHCP_FILENAME", help="PXE filename (after iPXE if --ipxe", default=DHCP_FILENAME)
+        parser.add_argument("-a", "--netboot", action="store", dest="NETBOOTDIR", help="File serve directory", default=NETBOOTDIR)
+        parser.add_argument("-i", "--filename", action="store", dest="DHCP_FILENAME", help="PXE filename (after iPXE if --ipxe", default='')
 
+        #parse the arguments given in the command line
         args = parser.parse_args()
+
+        #pass warning to user regarding starting HTTP server without iPXE
         if args.USE_HTTP and not args.USE_IPXE:
             print "\nWARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.\n"
-        if args.DHCP_PROXYDHCP:
+        
+        #if the argument was pased to enabled DHCP proxy mode then enable the DHCP server as well
+        if args.DHCP_PROXYMODE:
             args.USE_DHCP = True
 
-        os.chdir(args.NETBOOT)
+        #if the DHCP file name was not specified in the argument, set it based on what services were enabled/disabled
+        if args.DHCP_FILENAME == '':
+            if not args.USE_IPXE:
+                args.DHCP_FILENAME = "/pxelinux.0"
+            elif not args.USE_HTTP:
+                args.DHCP_FILENAME = "/boot.ipxe"
+            else:
+                args.DHCP_FILENAME = "/boot.http.ipxe"
+
+        os.chdir(args.NETBOOTDIR)
 
         #configure/start TFTP server
         tftpd = TFTPD()
@@ -75,11 +80,11 @@ if __name__ == '__main__':
 
         #configure/start DHCP server
         if args.USE_DHCP:
-            dhcpd = DHCPD(args.DHCP_FILESERVER_IP, args.DHCP_OFFER_BEGIN, args.DHCP_OFFER_END, args.DHCP_SUBNET, args.DHCP_ROUTER, args.DHCP_DNS, args.DHCP_FILENAME, args.DHCP_SERVER_IP, args.USE_IPXE, args.USE_HTTP, args.DHCP_PROXYDHCP)
+            dhcpd = DHCPD(args.DHCP_FILESERVER_IP, args.DHCP_OFFER_BEGIN, args.DHCP_OFFER_END, args.DHCP_SUBNET, args.DHCP_ROUTER, args.DHCP_DNS, args.DHCP_FILENAME, args.DHCP_SERVER_IP, args.USE_IPXE, args.USE_HTTP, args.DHCP_PROXYMODE)
             dhcpthread = threading.Thread(target=dhcpd.listen)
             dhcpthread.daemon = True
             dhcpthread.start()
-            if args.DHCP_PROXYDHCP:
+            if args.DHCP_PROXYMODE:
                 print 'Starting DHCP server in proxy mode...'
             else:
                 print 'Starting DHCP server...'


### PR DESCRIPTION
# Bug Fix

Fixed a bug where the DHCP file name would not be properly set because it is based off of defaults set above the parsed arguments. Resolved by using the arguments variables to determine what type of default file name should be used.
# Other Improvements

Moved default settings out of `__main__` since it’s pointless to set them there, better usability if they’re set at the very top. `server.py` is not meant to be included in another file, that’s why the server modules were split into separate files in an earlier commit (noted in Pull Request #5).

Removed some global variables and simple set the default argument values inline with the code rather than have them in two places and cause confusion.

Reformatted HTTP w/o PXE warning in `dhcpd.py` to match that in `server.py` for consistency.
