### PR TITLE
'argparse' Module Handling

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -78,3 +78,5 @@ The HTTP server class, ```HTTPD()``` requires three optional parameters be set i
 
 ##Additional Information
 The function ```chr(0)``` is used in multiple places throughout the servers. This denotes a ```NULL``` byte, or ```\x00```
+
+**Note:** Python 2.6 does not include the `argparse` module, it is included in the standard library as of 2.7 and newer. The `argparse` module is required to take in command line arguments and `server.py` will not run without it.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #About
-This repository contains code that provides a working PXE server (via HTTP, TFTP, DHCP, and/or iPXE) implemented purely in Python. Currently, only Python2 is supported.
+This repository contains code that provides a working PXE server (via HTTP, TFTP, DHCP, and/or iPXE) implemented purely in Python. Currently, only Python 2.6 and newer is supported.
 
 **DISCLAIMER:** None of these servers are fully compliant with any standards or specifications. However, the true specifications and standards were followed when building PyPXE and while they work for PXE any other uses are purely coincidental. Use at your own risk.
 
@@ -10,6 +10,8 @@ Each server type (TFTP/HTTP/DHCP) is in it's own class in it's own file and can 
 
 ###QuickStart
 ```server.py``` uses all three services in combination with the option of enabling/disabling them individually while also setting some options. Edit the ```server.py``` settings to your preferred settings or run with ```--help``` or ```-h``` to see what command line arguments you can pass. Treat the provided ```netboot``` directory as ```/tftpboot``` that you would typically see on a TFTP server, put all of your network-bootable files in there and setup your menu(s) in ```netboot/pxelinux.cfg/default```.
+
+**Note:** Python 2.6 does not include the `argparse` module, it is included in the standard library as of 2.7 and newer. The `argparse` module is required to take in command line arguments and `server.py` will not run without it.
 
 Simply run the following command and you will have an out-of-the-box PXE-bootable server that runs TFTP and serves files out of the ```netboot``` directory!
 ```

--- a/dhcpd.py
+++ b/dhcpd.py
@@ -83,9 +83,9 @@ class DHCPD:
         #convert both to 32bit integers
         
         #e.g '192.168.1.1' to 3232235777
-        encode = lambda x: struct.unpack("!I", socket.inet_aton(x))[0]
+        encode = lambda x: struct.unpack('!I', socket.inet_aton(x))[0]
         #e.g 3232235777 to '192.168.1.1'
-        decode = lambda x: socket.inet_ntoa(struct.pack("!I", x))
+        decode = lambda x: socket.inet_ntoa(struct.pack('!I', x))
         
         fromhost = encode(self.offerfrom)
         tohost = encode(self.offerto)
@@ -111,15 +111,15 @@ class DHCPD:
         '''
         ret = {}
         while(raw):
-            tag = struct.unpack("B", raw[0])[0]
+            tag = struct.unpack('B', raw[0])[0]
             if tag == 0:  # Padding
                 raw = raw[1:]
                 continue
             if tag == 255:  # End marker
                 break
-            length = struct.unpack("B", raw[1])[0]
-            value = raw[2:2+length]
-            raw = raw[2+length:]
+            length = struct.unpack('B', raw[1])[0]
+            value = raw[2:2 + length]
+            raw = raw[2 + length:]
             if tag in ret:
                 ret[tag].append(value)
             else:
@@ -190,7 +190,7 @@ class DHCPD:
             #Router
             response += self.tlvencode(3, socket.inet_aton(self.router))
             #Lease time
-            response += self.tlvencode(51, struct.pack("!I", 86400))
+            response += self.tlvencode(51, struct.pack('!I', 86400))
         #TFTP Server OR HTTP Server; if iPXE, need both
         response += self.tlvencode(66, self.fileserver)
         #Filename null terminated

--- a/server.py
+++ b/server.py
@@ -1,6 +1,12 @@
 import threading
 import os
-import argparse
+import sys
+
+try:
+    import argparse
+except ImportError:
+    sys.exit("ImportError: You do not have the Python 'argparse' module installed. Please install the 'argparse' module and try again.")
+
 from time import sleep
 from httpd import HTTPD
 from tftpd import TFTPD
@@ -116,4 +122,4 @@ if __name__ == '__main__':
             sleep(1)
 
     except KeyboardInterrupt:
-        print '\nShutting down PyPXE...\n'
+        sys.exit('\nShutting down PyPXE...\n')


### PR DESCRIPTION
## Proposal

If the user does not have the ‘argparse’ module installed then `server.py` will exit and display an error message. Without the module, `server.py` will not take in command line arguments properly.

If users do not have the 'argparse' module installed then running `server.py` will result in a clean exit with an error notification:

```
#sudo python server.py
ImportError: You do not have the Python 'argparse' module installed. Please install the 'argparse' module and try again.
```

This only affects users using older than Python 2.7 because as of 2.7 it is maintained in the standard library. The documentation (`README.md` and `DOCUMENTATION.md`) as well as `server.py` were updated to reflect this.
## Reasoning

Since the majority of Python users will have 2.7 and those who don't need only install a single module that is in the standard library I think it's safe to simply exit cleanly and tell them specifically what module to install. A simple Google search for 'install argparse module' yields [this result](http://stackoverflow.com/questions/15330175/how-can-i-get-argparse-in-python-2-6) as number two and is one of several extremely easy methods to install the 'argparse' module. User eas-of-use is only minorly affected by this.
## Other Notes

Corrected some minor quote inconsistencies and whitespace issues.

Also implemented the clean exit when shutting down iPXE with KeyboardInterrupt.
