### PR TITLE
Python logging module support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -81,6 +81,7 @@ The TFTP server class, __`TFTPD()`__, is constructed with the following __keywor
 * __`logger`__
   * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
   * Default: `None` 
+
 ##DHCP Server `pypxe.dhcp`
 
 ###Importing

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -151,6 +151,9 @@ The DHCP server class, __`DHCPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the DHCP server should be started in debug mode or not.
   * Default: `False`
   * Type: _bool_
+* __`logger`__
+  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
+  * Default: `None` 
 
 ##HTTP Server `pypxe.http`
 
@@ -181,6 +184,9 @@ The HTTP server class, __`HTTPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the HTTP server should be started in debug mode or not.
   * Default: `False`
   * Type: bool
+* __`logger`__
+  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
+  * Default: `None` 
 
 ##Additional Information
 * The function `chr(0)` is used in multiple places throughout the servers. This denotes a `NULL` byte, or `\x00`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -78,7 +78,9 @@ The TFTP server class, __`TFTPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the TFTP server should be started in debug mode or not.
   * Default: `False`
   * Type: bool
-
+* __`logger`__
+  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
+  * Default: `None` 
 ##DHCP Server `pypxe.dhcp`
 
 ###Importing

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The following are arguments that can be passed to `pypxe-server.py` when running
     * Description: Enable selected services in DEBUG mode
       * _This adds a level of verbosity so that you can see what's happening in the background. Debug statements are prefixed with `[DEBUG]` and indented to distinguish between normal output that the services give._
     * Default: `False`
+  * __`--syslog`__
+    * Description: Syslog server
+    * Default: `None`
+  * __`--syslog-port`__
+    * Description: Syslog server port
+    * Default: `514`
 * __DHCP Service Arguments__ _each of the following can be set one of two ways, you can use either/or_
   * __`-s DHCP_SERVER_IP`__ or __`--dhcp-server-ip DHCP_SERVER_IP`__
     * Description: Specify DHCP server IP address

--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -1,6 +1,7 @@
 import threading
 import os
 import sys
+import logging
 
 try:
     import argparse
@@ -45,7 +46,8 @@ if __name__ == '__main__':
         parser.add_argument('--http', action = 'store_true', dest = 'USE_HTTP', help = 'Enable built-in HTTP server', default = False)
         parser.add_argument('--no-tftp', action = 'store_false', dest = 'USE_TFTP', help = 'Disable built-in TFTP server, by default it is enabled', default = True)
         parser.add_argument('--debug', action = 'store_true', dest = 'MODE_DEBUG', help = 'Adds verbosity to the selected services while they run', default = False)
-        
+        parser.add_argument('--syslog', action = 'store', dest = 'SYSLOG_SERVER', help = 'Syslog server', default = None)
+
         #argument group for DHCP server
         exclusive = parser.add_mutually_exclusive_group(required = False)
         exclusive.add_argument('--dhcp', action = 'store_true', dest = 'USE_DHCP', help = 'Enable built-in DHCP server', default = False)
@@ -67,9 +69,22 @@ if __name__ == '__main__':
         #parse the arguments given
         args = parser.parse_args()
 
+        # setup logger
+        logger = logging.getLogger(sys.argv[0])
+        if args.SYSLOG_SERVER:
+            handler = logging.handlers.SysLogHandler(address = SYSLOG_SERVER)
+        else:
+            handler = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        if args.MODE_DEBUG:
+            logger.setLevel(logging.DEBUG)
+
         #pass warning to user regarding starting HTTP server without iPXE
         if args.USE_HTTP and not args.USE_IPXE and not args.USE_DHCP:
-            print '\nWARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.\n'
+            logger.warning('HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
         
         #if the argument was pased to enabled ProxyDHCP then enable the DHCP server
         if args.DHCP_MODE_PROXY:
@@ -92,8 +107,8 @@ if __name__ == '__main__':
 
         #configure/start TFTP server
         if args.USE_TFTP:
-            print 'Starting TFTP server...'
-            tftpServer = tftp.TFTPD(mode_debug = args.MODE_DEBUG)
+            logger.info('Starting TFTP server...')
+            tftpServer = tftp.TFTPD(logger = logger)
             tftpd = threading.Thread(target = tftpServer.listen)
             tftpd.daemon = True
             tftpd.start()
@@ -102,9 +117,9 @@ if __name__ == '__main__':
         #configure/start DHCP server
         if args.USE_DHCP:
             if args.DHCP_MODE_PROXY:
-                print 'Starting DHCP server in ProxyDHCP mode...'
+                logger.info('Starting DHCP server in ProxyDHCP mode...')
             else:
-                print 'Starting DHCP server...'
+                logger.info('Starting DHCP server...')
             dhcpServer = dhcp.DHCPD(
                     ip = args.DHCP_SERVER_IP,
                     port = args.DHCP_SERVER_PORT,
@@ -119,7 +134,7 @@ if __name__ == '__main__':
                     useipxe = args.USE_IPXE,
                     usehttp = args.USE_HTTP,
                     mode_proxy = args.DHCP_MODE_PROXY,
-                    mode_debug = args.MODE_DEBUG)
+                    logger = logger)
             dhcpd = threading.Thread(target = dhcpServer.listen)
             dhcpd.daemon = True
             dhcpd.start()
@@ -128,14 +143,14 @@ if __name__ == '__main__':
 
         #configure/start HTTP server
         if args.USE_HTTP:
-            print 'Starting HTTP server...'
-            httpServer = http.HTTPD(mode_debug = args.MODE_DEBUG)
+            logger.info('Starting HTTP server...')
+            httpServer = http.HTTPD(logger = logger)
             httpd = threading.Thread(target = httpServer.listen)
             httpd.daemon = True
             httpd.start()
             runningServices.append(httpd)
 
-        print 'PyPXE successfully initialized and running!'
+        logger.info('PyPXE successfully initialized and running!')
 
         while map(lambda x: x.isAlive(), runningServices):
             sleep(1)

--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -2,6 +2,7 @@ import threading
 import os
 import sys
 import logging
+import logging.handlers
 
 try:
     import argparse
@@ -47,6 +48,7 @@ if __name__ == '__main__':
         parser.add_argument('--no-tftp', action = 'store_false', dest = 'USE_TFTP', help = 'Disable built-in TFTP server, by default it is enabled', default = True)
         parser.add_argument('--debug', action = 'store_true', dest = 'MODE_DEBUG', help = 'Adds verbosity to the selected services while they run', default = False)
         parser.add_argument('--syslog', action = 'store', dest = 'SYSLOG_SERVER', help = 'Syslog server', default = None)
+        parser.add_argument('--syslog-port', action = 'store', dest = 'SYSLOG_PORT', help = 'Syslog server port', default = 514)
 
         #argument group for DHCP server
         exclusive = parser.add_mutually_exclusive_group(required = False)
@@ -72,7 +74,7 @@ if __name__ == '__main__':
         # setup logger
         logger = logging.getLogger(sys.argv[0])
         if args.SYSLOG_SERVER:
-            handler = logging.handlers.SysLogHandler(address = SYSLOG_SERVER)
+            handler = logging.handlers.SysLogHandler(address = (args.SYSLOG_SERVER, int(args.SYSLOG_PORT)))
         else:
             handler = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')

--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
         #configure/start TFTP server
         if args.USE_TFTP:
             logger.info('Starting TFTP server...')
-            tftpServer = tftp.TFTPD(logger = logger)
+            tftpServer = tftp.TFTPD(mode_debug = args.MODE_DEBUG, logger = logger)
             tftpd = threading.Thread(target = tftpServer.listen)
             tftpd.daemon = True
             tftpd.start()
@@ -136,6 +136,7 @@ if __name__ == '__main__':
                     useipxe = args.USE_IPXE,
                     usehttp = args.USE_HTTP,
                     mode_proxy = args.DHCP_MODE_PROXY,
+                    mode_debug = args.MODE_DEBUG,
                     logger = logger)
             dhcpd = threading.Thread(target = dhcpServer.listen)
             dhcpd.daemon = True
@@ -146,7 +147,7 @@ if __name__ == '__main__':
         #configure/start HTTP server
         if args.USE_HTTP:
             logger.info('Starting HTTP server...')
-            httpServer = http.HTTPD(logger = logger)
+            httpServer = http.HTTPD(mode_debug = args.MODE_DEBUG, logger = logger)
             httpd = threading.Thread(target = httpServer.listen)
             httpd.daemon = True
             httpd.start()

--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -32,8 +32,22 @@ class DHCPD:
         self.ipxe = serverSettings.get('useipxe', False)
         self.http = serverSettings.get('usehttp', False)
         self.mode_proxy = serverSettings.get('mode_proxy', False) #ProxyDHCP mode
-        self.logger =  serverSettings.get('logger')
+        self.logger =  serverSettings.get('logger', None)
+        self.mode_debug =  serverSettings.get('mode_debug', False)
         self.magic = struct.pack('!I', 0x63825363) #magic cookie
+
+        if self.logger == None:
+            import logging
+            import logging.handlers
+            # setup logger
+            self.logger = logging.getLogger("dhcp")
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+            if self.mode_debug:
+                self.logger.setLevel(logging.DEBUG)
 
         if self.http and not self.ipxe:
             self.logger.warning('HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')

--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -32,30 +32,29 @@ class DHCPD:
         self.ipxe = serverSettings.get('useipxe', False)
         self.http = serverSettings.get('usehttp', False)
         self.mode_proxy = serverSettings.get('mode_proxy', False) #ProxyDHCP mode
-        self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
+        self.logger =  serverSettings.get('logger')
         self.magic = struct.pack('!I', 0x63825363) #magic cookie
 
         if self.http and not self.ipxe:
-            print '\nWARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.\n'
+            self.logger.warning('HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
         if self.ipxe and self.http:
             self.filename = 'http://%s/%s' % (self.fileserver, self.filename)
         if self.ipxe and not self.http:
             self.filename = 'tftp://%s/%s' % (self.fileserver, self.filename)
 
-        if self.mode_debug:
-            print 'NOTICE: DHCP server started in debug mode. DHCP server is using the following:'
-            print '\tDHCP Server IP: ' + self.ip
-            print '\tDHCP Server Port: ' + str (self.port)
-            print '\tDHCP Lease Range: ' + self.offerfrom + ' - ' + self.offerto
-            print '\tDHCP Subnet Mask: ' + self.subnetmask
-            print '\tDHCP Router: ' + self.router
-            print '\tDHCP DNS Server: ' + self.dnsserver
-            print '\tDHCP Broadcast Address: ' + self.broadcast
-            print '\tDHCP File Server IP: ' + self.fileserver
-            print '\tDHCP File Name: ' + self.filename
-            print '\tProxyDHCP Mode: ' + str(self.mode_proxy)
-            print '\tUsing iPXE: ' + str(self.ipxe)
-            print '\tUsing HTTP Server: ' + str(self.http)
+        self.logger.debug('NOTICE: DHCP server started in debug mode. DHCP server is using the following:')
+        self.logger.debug('\tDHCP Server IP: ' + self.ip)
+        self.logger.debug('\tDHCP Server Port: ' + str (self.port))
+        self.logger.debug('\tDHCP Lease Range: ' + self.offerfrom + ' - ' + self.offerto)
+        self.logger.debug('\tDHCP Subnet Mask: ' + self.subnetmask)
+        self.logger.debug('\tDHCP Router: ' + self.router)
+        self.logger.debug('\tDHCP DNS Server: ' + self.dnsserver)
+        self.logger.debug('\tDHCP Broadcast Address: ' + self.broadcast)
+        self.logger.debug('\tDHCP File Server IP: ' + self.fileserver)
+        self.logger.debug('\tDHCP File Name: ' + self.filename)
+        self.logger.debug('\tProxyDHCP Mode: ' + str(self.mode_proxy))
+        self.logger.debug('\tUsing iPXE: ' + str(self.ipxe))
+        self.logger.debug('\tUsing HTTP Server: ' + str(self.http))
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -147,11 +146,11 @@ class DHCPD:
                 offer = self.nextIP()
                 self.leases[clientmac]['ip'] = offer
                 self.leases[clientmac]['expire'] = time() + 86400
-                if self.mode_debug:
-                    print '[DEBUG] New DHCP Assignment - MAC: ' + self.printMAC(clientmac) + ' -> IP: ' + self.leases[clientmac]['ip']
+                self.logger.debug('New DHCP Assignment - MAC: ' + self.printMAC(clientmac) + ' -> IP: ' + self.leases[clientmac]['ip'])
             response += socket.inet_aton(offer) #yiaddr
         else:
             response += socket.inet_aton('0.0.0.0')
+
         response += socket.inet_aton(self.fileserver) #siaddr
         response += socket.inet_aton('0.0.0.0') #giaddr
         response += chaddr #chaddr
@@ -201,11 +200,10 @@ class DHCPD:
         clientmac, headerResponse = self.craftHeader(message)
         optionsResponse = self.craftOptions(2, clientmac) #DHCPOFFER
         response = headerResponse + optionsResponse
-        if self.mode_debug:
-            print '[DEBUG] DHCPOFFER - Sending the following'
-            print '\t<--BEGIN HEADER-->\n\t' + repr(headerResponse) + '\n\t<--END HEADER-->'
-            print '\t<--BEGIN OPTIONS-->\n\t' + repr(optionsResponse) + '\n\t<--END OPTIONS-->'
-            print '\t<--BEGIN RESPONSE-->\n\t' + repr(response) + '\n\t<--END RESPONSE-->'
+        self.logger.debug('DHCPOFFER - Sending the following')
+        self.logger.debug('\t<--BEGIN HEADER-->\n\t' + repr(headerResponse) + '\n\t<--END HEADER-->')
+        self.logger.debug('\t<--BEGIN OPTIONS-->\n\t' + repr(optionsResponse) + '\n\t<--END OPTIONS-->')
+        self.logger.debug('\t<--BEGIN RESPONSE-->\n\t' + repr(response) + '\n\t<--END RESPONSE-->')
         self.sock.sendto(response, (self.broadcast, 68))
 
     def dhcpAck(self, message):
@@ -213,11 +211,10 @@ class DHCPD:
         clientmac, headerResponse = self.craftHeader(message)
         optionsResponse = self.craftOptions(5, clientmac) #DHCPACK
         response = headerResponse + optionsResponse
-        if self.mode_debug:
-            print '[DEBUG] DHCPACK - Sending the following'
-            print '\t<--BEGIN HEADER-->\n\t' + repr(headerResponse) + '\n\t<--END HEADER-->'
-            print '\t<--BEGIN OPTIONS-->\n\t' + repr(optionsResponse) + '\n\t<--END OPTIONS-->'
-            print '\t<--BEGIN RESPONSE-->\n\t' + repr(response) + '\n\t<--END RESPONSE-->'
+        self.logger.debug('DHCPACK - Sending the following')
+        self.logger.debug('\t<--BEGIN HEADER-->\n\t' + repr(headerResponse) + '\n\t<--END HEADER-->')
+        self.logger.debug('\t<--BEGIN OPTIONS-->\n\t' + repr(optionsResponse) + '\n\t<--END OPTIONS-->')
+        self.logger.debug('\t<--BEGIN RESPONSE-->\n\t' + repr(response) + '\n\t<--END RESPONSE-->')
         self.sock.sendto(response, (self.broadcast, 68))
 
     def listen(self):
@@ -225,24 +222,19 @@ class DHCPD:
         while True:
             message, address = self.sock.recvfrom(1024)
             clientmac = struct.unpack('!28x6s', message[:34])
-            if self.mode_debug:
-                print '[DEBUG] Received message'
-                print '\t<--BEGIN MESSAGE-->\n\t' + repr(message) + '\n\t<--END MESSAGE-->'
+            self.logger.debug('Received message')
+            self.logger.debug('\t<--BEGIN MESSAGE-->\n\t' + repr(message) + '\n\t<--END MESSAGE-->')
             options = self.tlvParse(message[240:])
-            if self.mode_debug:
-                print '[DEBUG] Parsed received options'
-                print '\t<--BEGIN OPTIONS-->\n\t' + repr(options) + '\n\t<--END OPTIONS-->'
-            if not (60 in options and 'PXEClient' in options[60][0]) : continue
+            self.logger.debug('Parsed received options')
+            self.logger.debug('\t<--BEGIN OPTIONS-->\n\t' + repr(options) + '\n\t<--END OPTIONS-->')
+            #if not (60 in options and 'PXEClient' in options[60][0]) : continue
             type = ord(options[53][0]) #see RFC2131 page 10
             if type == 1:
-                if self.mode_debug:
-                    print '[DEBUG] Received DHCPOFFER'
+                self.logger.debug('Received DHCPOFFER')
                 self.dhcpOffer(message)
             elif type == 3 and address[0] == '0.0.0.0' and not self.mode_proxy:
-                if self.mode_debug:
-                    print '[DEBUG] Received DHCPACK'
+                self.logger.debug('Received DHCPACK')
                 self.dhcpAck(message)
             elif type == 3 and address[0] != '0.0.0.0' and self.mode_proxy:
-                if self.mode_debug:
-                    print '[DEBUG] Received DHCPACK'
+                self.logger.debug('Received DHCPACK')
                 self.dhcpAck(message)

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -18,7 +18,8 @@ class HTTPD:
         self.ip = serverSettings.get('ip', '0.0.0.0')
         self.port = serverSettings.get('port', 80)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
-        self.logger = serverSettings.get('logger')
+        self.logger = serverSettings.get('logger', None)
+        self.mode_debug = serverSettings.get('mode_debug', False)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
@@ -28,6 +29,20 @@ class HTTPD:
         # this simplifies target later as well as offers a slight security increase
         os.chdir (self.netbootDirectory)
         os.chroot ('.')
+
+        if self.logger == None:
+            import logging
+            import logging.handlers
+            # setup logger
+            self.logger = logging.getLogger("http")
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+            if self.mode_debug:
+                self.logger.setLevel(logging.DEBUG)
+
 
         self.logger.debug('NOTICE: HTTP server started in debug mode. HTTP server is using the following:')
         self.logger.debug('\tHTTP Server IP: ' + self.ip)

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -18,7 +18,7 @@ class HTTPD:
         self.ip = serverSettings.get('ip', '0.0.0.0')
         self.port = serverSettings.get('port', 80)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
-        self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
+        self.logger = serverSettings.get('logger')
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
@@ -29,18 +29,16 @@ class HTTPD:
         os.chdir (self.netbootDirectory)
         os.chroot ('.')
 
-        if self.mode_debug:
-            print 'NOTICE: HTTP server started in debug mode. HTTP server is using the following:'
-            print '\tHTTP Server IP: ' + self.ip
-            print '\tHTTP Server Port: ' + str(self.port)
-            print '\tHTTP Network Boot Directory: ' + self.netbootDirectory
+        self.logger.debug('NOTICE: HTTP server started in debug mode. HTTP server is using the following:')
+        self.logger.debug('\tHTTP Server IP: ' + self.ip)
+        self.logger.debug('\tHTTP Server Port: ' + str(self.port))
+        self.logger.debug('\tHTTP Network Boot Directory: ' + self.netbootDirectory)
 
     def handleRequest(self, connection, addr):
         '''This method handles HTTP request'''
         request = connection.recv(1024)
-        if self.mode_debug:
-            print '[DEBUG] HTTP Recieved message from ' + repr(addr)
-            print '\t<--BEGIN MESSAGE-->\n\t' + repr(request) + '\n\t<--END MESSAGE-->'
+        self.logger.debug('HTTP Recieved message from ' + repr(addr))
+        self.logger.debug('\n\t<--BEGIN MESSAGE-->\n\t' + repr(request) + '\n\t<--END MESSAGE-->')
         startline = request.split('\r\n')[0].split(' ')
         method = startline[0]
         target = startline[1]
@@ -54,28 +52,25 @@ class HTTPD:
         if status[:3] in ('404', '501'): #fail out
             connection.send(response)
             connection.close()
-            if self.mode_debug:
-                print '[DEBUG] HTTP Sending message to ' + repr(addr)
-                print '\t<--BEING MESSAGE-->\n\t' + repr(response) + '\n\t<--END MESSAGE-->'
+            self.logger.debug('HTTP Sending message to ' + repr(addr))
+            self.logger.debug('\n\t<--BEING MESSAGE-->\n\t' + repr(response) + '\n\t<--END MESSAGE-->')
             return
         response += 'Content-Length: %d\r\n' % os.path.getsize(target)
         response += '\r\n'
         if method == 'HEAD':
             connection.send(response)
             connection.close()
-            if self.mode_debug:
-                print '[DEBUG] HTTP Sending message to ' + repr(addr)
-                print '\t<--BEING MESSAGE-->\n\t' + repr(response) + '\n\t<--END MESSAGE-->'
+            self.logger.debug('HTTP Sending message to ' + repr(addr))
+            self.logger.debug('\n\t<--BEING MESSAGE-->\n\t' + repr(response) + '\n\t<--END MESSAGE-->')
             return
         handle = open(target)
         response += handle.read()
         handle.close()
         connection.send(response)
         connection.close()
-        if self.mode_debug:
-            print '[DEBUG] HTTP Sending message to ' + repr(addr)
-            print '\t<--BEING MESSAGE-->\n\t' + repr(response) + '\n\t<--END MESSAGE-->'
-            print '\tHTTP File Sent - http://%s -> %s:%d' % (target, addr[0], addr[1])
+        self.logger.debug('HTTP Sending message to ' + repr(addr))
+        self.logger.debug('\n\t<--BEING MESSAGE-->\n\t' + repr(response) + '\n\t<--END MESSAGE-->')
+        self.logger.debug('\tHTTP File Sent - http://%s -> %s:%d' % (target, addr[0], addr[1]))
 
     def listen(self):
         '''This method is the main loop that listens for requests'''

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -16,18 +16,17 @@ class TFTPD:
     '''
     def __init__(self, **serverSettings):
         self.ip = serverSettings.get('ip', '0.0.0.0')
-        self.port = serverSettings.get('port', 69)
+        self.port = serverSettings.get('port', 79)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
-        self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
+        self.logger = serverSettings.get('logger')
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
 
-        if self.mode_debug:
-            print 'NOTICE: TFTP server started in debug mode. TFTP server is using the following:'
-            print '\tTFTP Server IP: ' + self.ip
-            print '\tTFTP Server Port: ' + str(self.port)
-            print '\tTFTP Network Boot Directory: ' + self.netbootDirectory
+        self.logger.debug('NOTICE: TFTP server started in debug mode. TFTP server is using the following:')
+        self.logger.debug('\tTFTP Server IP: ' + self.ip)
+        self.logger.debug('\tTFTP Server Port: ' + str(self.port))
+        self.logger.debug('\tTFTP Network Boot Directory: ' + self.netbootDirectory)
 
         #key is (address, port) pair
         self.ongoing = defaultdict(lambda: {'filename': '', 'handle': None, 'block': 1, 'blksize': 512})
@@ -55,8 +54,7 @@ class TFTPD:
         response =  struct.pack('!H', 5) #error code
         response += struct.pack('!H', 1) #file not found
         response += 'File Not Found'
-        if self.mode_debug:
-            print "[DEBUG] TFTP Sending 'File Not Found'"
+        self.logger.debug("TFTP Sending 'File Not Found'")
         self.sock.sendto(response, address)
 
     def sendBlock(self, address):
@@ -71,12 +69,10 @@ class TFTPD:
         self.sock.sendto(response, address)
         if len(data) != descriptor['blksize']:
             descriptor['handle'].close()
-            if self.mode_debug:
-                print '[DEBUG] TFTP File Sent - tftp://%s -> %s:%d' % (descriptor['filename'], address[0], address[1])
+            self.logger.debug('TFTP File Sent - tftp://%s -> %s:%d' % (descriptor['filename'], address[0], address[1]))
             self.ongoing.pop(address)
         else:
-            if self.mode_debug:
-                print '[DEBUG] TFTP Sending block ' + repr(descriptor['block'])
+            self.logger.debug('TFTP Sending block ' + repr(descriptor['block']))
             descriptor['block'] += 1
 
     def read(self, address, message):
@@ -86,7 +82,8 @@ class TFTPD:
                 file does not exist -> reply with error
         '''
         filename = self.filename(message)
-        if not os.path.lexists(filename):
+        self.logger.debug('Filename: %s' % filename)
+        if not os.path.isfile(filename):
             self.notFound(address)
             return
         self.ongoing[address]['filename'] = filename
@@ -101,8 +98,8 @@ class TFTPD:
             self.ongoing[address]['blksize'] = int(options['blksize'])
         filesize = os.path.getsize(self.ongoing[address]['filename'])
         if filesize > (2**16 * self.ongoing[address]['blksize']):
-            print '\nWARNING: TFTP request too big, attempting transfer anyway.\n'
-            print '\tDetails: Filesize %s is too big for blksize %s.\n' % (filesize, self.ongoing[address]['blksize'])
+            self.logger.warning('TFTP request too big, attempting transfer anyway.\n')
+            self.logger.warning('Details: Filesize %s is too big for blksize %s.\n' % (filesize, self.ongoing[address]['blksize']))
         if 'tsize' in options:
             response += 'tsize' + chr(0)
             response += str(filesize)
@@ -118,8 +115,7 @@ class TFTPD:
             message, address = self.sock.recvfrom(1024)
             opcode = struct.unpack('!H', message[:2])[0]
             if opcode == 1: #read the request
-                if self.mode_debug:
-                    print '[DEBUG] TFTP receiving request'
+                self.logger.debug('TFTP receiving request')
                 self.read(address, message)
             if opcode == 4:
                  if self.ongoing.has_key(address):

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -16,12 +16,26 @@ class TFTPD:
     '''
     def __init__(self, **serverSettings):
         self.ip = serverSettings.get('ip', '0.0.0.0')
-        self.port = serverSettings.get('port', 79)
+        self.port = serverSettings.get('port', 69)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
-        self.logger = serverSettings.get('logger')
+        self.logger = serverSettings.get('logger', None)
+        self.mode_debug = serverSettings.get('mode_debug', False)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
+
+        if self.logger == None:
+            import logging
+            import logging.handlers
+            # setup logger
+            self.logger = logging.getLogger("tftp")
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+            if self.mode_debug:
+                self.logger.setLevel(logging.DEBUG)
 
         self.logger.debug('NOTICE: TFTP server started in debug mode. TFTP server is using the following:')
         self.logger.debug('\tTFTP Server IP: ' + self.ip)
@@ -35,6 +49,7 @@ class TFTPD:
         # this simplifies target later as well as offers a slight security increase
         os.chdir (self.netbootDirectory)
         os.chroot ('.')
+
 
     def filename(self, message):
         '''


### PR DESCRIPTION
This patch adds support for python [logging](https://docs.python.org/2/library/logging.html) module.
This makes PyPXE compatibile with software using the logging module.
This patch is backward compatible: you're not obliged to use logging in your project: each module can instantiate a local (StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) if no logger is received in the constructor.