### PR TITLE
Logging via logging module

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -78,6 +78,9 @@ The TFTP server class, __`TFTPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the TFTP server should be started in debug mode or not.
   * Default: `False`
   * Type: bool
+* __`logger`__
+  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
+  * Default: `None`
 
 ##DHCP Server `pypxe.dhcp`
 
@@ -148,6 +151,9 @@ The DHCP server class, __`DHCPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the DHCP server should be started in debug mode or not.
   * Default: `False`
   * Type: _bool_
+* __`logger`__
+  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
+  * Default: `None`
 
 ##HTTP Server `pypxe.http`
 
@@ -178,6 +184,9 @@ The HTTP server class, __`HTTPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the HTTP server should be started in debug mode or not.
   * Default: `False`
   * Type: bool
+* __`logger`__
+  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
+  * Default: `None`
 
 ##Additional Information
 * The function `chr(0)` is used in multiple places throughout the servers. This denotes a `NULL` byte, or `\x00`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -78,9 +78,6 @@ The TFTP server class, __`TFTPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the TFTP server should be started in debug mode or not.
   * Default: `False`
   * Type: bool
-* __`logger`__
-  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
-  * Default: `None` 
 
 ##DHCP Server `pypxe.dhcp`
 
@@ -151,9 +148,6 @@ The DHCP server class, __`DHCPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the DHCP server should be started in debug mode or not.
   * Default: `False`
   * Type: _bool_
-* __`logger`__
-  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
-  * Default: `None` 
 
 ##HTTP Server `pypxe.http`
 
@@ -184,9 +178,6 @@ The HTTP server class, __`HTTPD()`__, is constructed with the following __keywor
   * Description: This indicates whether or not the HTTP server should be started in debug mode or not.
   * Default: `False`
   * Type: bool
-* __`logger`__
-  * Description: A [Logger](https://docs.python.org/2/library/logging.html#logger-objects) object used for logging messages, if `None` a local [StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) instance will be created
-  * Default: `None` 
 
 ##Additional Information
 * The function `chr(0)` is used in multiple places throughout the servers. This denotes a `NULL` byte, or `\x00`

--- a/README.md
+++ b/README.md
@@ -64,12 +64,6 @@ The following are arguments that can be passed to `pypxe-server.py` when running
     * Description: Amend configuration from json file
      * _Use the specified json file to amend the command line options. See example.json for more information._
     * Default: `None`
-  * __`--syslog`__
-    * Description: Syslog server
-    * Default: `None`
-  * __`--syslog-port`__
-    * Description: Syslog server port
-    * Default: `514`
 * __DHCP Service Arguments__ _each of the following can be set one of two ways, you can use either/or_
   * __`-s DHCP_SERVER_IP`__ or __`--dhcp-server-ip DHCP_SERVER_IP`__
     * Description: Specify DHCP server IP address

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ The following are arguments that can be passed to `pypxe-server.py` when running
     * Description: Amend configuration from json file
      * _Use the specified json file to amend the command line options. See example.json for more information._
     * Default: `None`
+  * __`--syslog`__
+    * Description: Syslog server
+    * Default: `None`
+  * __`--syslog-port`__
+    * Description: Syslog server port
+    * Default: `514`
 * __DHCP Service Arguments__ _each of the following can be set one of two ways, you can use either/or_
   * __`-s DHCP_SERVER_IP`__ or __`--dhcp-server-ip DHCP_SERVER_IP`__
     * Description: Specify DHCP server IP address

--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -7,6 +7,7 @@ This file contains classes and functions that implement the PyPXE DHCP service
 import socket
 import struct
 import os
+import logging
 from collections import defaultdict
 from time import time
 
@@ -39,28 +40,39 @@ class DHCPD:
         self.mode_proxy = serverSettings.get('mode_proxy', False) #ProxyDHCP mode
         self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
         self.magic = struct.pack('!I', 0x63825363) #magic cookie
+        self.logger = serverSettings.get('logger', None)
+
+        # setup logger
+        if self.logger == None:
+            self.logger = logging.getLogger("DHCP")
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s %(name)s [%(levelname)s] %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+        if self.mode_debug:
+            self.logger.setLevel(logging.DEBUG)
 
         if self.http and not self.ipxe:
-            print '\nWARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.\n'
+            self.logger.warning('WARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
         if self.ipxe and self.http:
             self.filename = 'http://{fileserver}/{filename}'.format(fileserver = self.fileserver, filename = self.filename)
         if self.ipxe and not self.http:
             self.filename = 'tftp://{fileserver}/{filename}'.format(fileserver = self.fileserver, filename = self.filename)
 
-        if self.mode_debug:
-            print 'NOTICE: DHCP server started in debug mode. DHCP server is using the following:'
-            print '\tDHCP Server IP: {}'.format(self.ip)
-            print '\tDHCP Server Port: {}'.format(self.port)
-            print '\tDHCP Lease Range: {} - {}'.format(self.offerfrom, self.offerto)
-            print '\tDHCP Subnet Mask: {}'.format(self.subnetmask)
-            print '\tDHCP Router: {}'.format(self.router)
-            print '\tDHCP DNS Server: {}'.format(self.dnsserver)
-            print '\tDHCP Broadcast Address: {}'.format(self.broadcast)
-            print '\tDHCP File Server IP: {}'.format(self.fileserver)
-            print '\tDHCP File Name: {}'.format(self.filename)
-            print '\tProxyDHCP Mode: {}'.format(self.mode_proxy)
-            print '\tUsing iPXE: {}'.format(self.ipxe)
-            print '\tUsing HTTP Server: {}'.format(self.http)
+        self.logger.debug('NOTICE: DHCP server started in debug mode. DHCP server is using the following:')
+        self.logger.debug('  DHCP Server IP: {}'.format(self.ip))
+        self.logger.debug(' DHCP Server Port: {}'.format(self.port))
+        self.logger.debug('  DHCP Lease Range: {} - {}'.format(self.offerfrom, self.offerto))
+        self.logger.debug('  DHCP Subnet Mask: {}'.format(self.subnetmask))
+        self.logger.debug('  DHCP Router: {}'.format(self.router))
+        self.logger.debug('  DHCP DNS Server: {}'.format(self.dnsserver))
+        self.logger.debug('  DHCP Broadcast Address: {}'.format(self.broadcast))
+        self.logger.debug('  DHCP File Server IP: {}'.format(self.fileserver))
+        self.logger.debug('  DHCP File Name: {}'.format(self.filename))
+        self.logger.debug('  ProxyDHCP Mode: {}'.format(self.mode_proxy))
+        self.logger.debug('  tUsing iPXE: {}'.format(self.ipxe))
+        self.logger.debug('  Using HTTP Server: {}'.format(self.http))
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -152,8 +164,7 @@ class DHCPD:
                 offer = self.nextIP()
                 self.leases[clientmac]['ip'] = offer
                 self.leases[clientmac]['expire'] = time() + 86400
-                if self.mode_debug:
-                    print '[DEBUG] New DHCP Assignment - MAC: {MAC} -> IP: {IP}'.format(MAC = self.printMAC(clientmac), IP = self.leases[clientmac]['ip'])
+                self.logger.debug('New DHCP Assignment - MAC: {MAC} -> IP: {IP}'.format(MAC = self.printMAC(clientmac), IP = self.leases[clientmac]['ip']))
             response += socket.inet_aton(offer) #yiaddr
         else:
             response += socket.inet_aton('0.0.0.0')
@@ -218,11 +229,10 @@ class DHCPD:
         clientmac, headerResponse = self.craftHeader(message)
         optionsResponse = self.craftOptions(2, clientmac) #DHCPOFFER
         response = headerResponse + optionsResponse
-        if self.mode_debug:
-            print '[DEBUG] DHCPOFFER - Sending the following'
-            print '\t<--BEGIN HEADER-->\n\t{headerResponse}\n\t<--END HEADER-->'.format(headerResponse = repr(headerResponse))
-            print '\t<--BEGIN OPTIONS-->\n\t{optionsResponse}\n\t<--END OPTIONS-->'.format(optionsResponse = repr(optionsResponse))
-            print '\t<--BEGIN RESPONSE-->\n\t{response}\n\t<--END RESPONSE-->'.format(response = repr(response))
+        self.logger.debug('DHCPOFFER - Sending the following')
+        self.logger.debug('  <--BEGIN HEADER-->\n\t{headerResponse}\n\t<--END HEADER-->'.format(headerResponse = repr(headerResponse)))
+        self.logger.debug('  <--BEGIN OPTIONS-->\n\t{optionsResponse}\n\t<--END OPTIONS-->'.format(optionsResponse = repr(optionsResponse)))
+        self.logger.debug('  <--BEGIN RESPONSE-->\n\t{response}\n\t<--END RESPONSE-->'.format(response = repr(response)))
         self.sock.sendto(response, (self.broadcast, 68))
 
     def dhcpAck(self, message):
@@ -230,11 +240,10 @@ class DHCPD:
         clientmac, headerResponse = self.craftHeader(message)
         optionsResponse = self.craftOptions(5, clientmac) #DHCPACK
         response = headerResponse + optionsResponse
-        if self.mode_debug:
-            print '[DEBUG] DHCPACK - Sending the following'
-            print '\t<--BEGIN HEADER-->\n\t{headerResponse}\n\t<--END HEADER-->'.format(headerResponse = repr(headerResponse))
-            print '\t<--BEGIN OPTIONS-->\n\t{optionsResponse}\n\t<--END OPTIONS-->'.format(optionsResponse = repr(optionsResponse))
-            print '\t<--BEGIN RESPONSE-->\n\t{response}\n\t<--END RESPONSE-->'.format(response = repr(response))
+        self.logger.debug('DHCPACK - Sending the following')
+        self.logger.debug('  <--BEGIN HEADER-->\n\t{headerResponse}\n\t<--END HEADER-->'.format(headerResponse = repr(headerResponse)))
+        self.logger.debug('  <--BEGIN OPTIONS-->\n\t{optionsResponse}\n\t<--END OPTIONS-->'.format(optionsResponse = repr(optionsResponse)))
+        self.logger.debug('  <--BEGIN RESPONSE-->\n\t{response}\n\t<--END RESPONSE-->'.format(response = repr(response)))
         self.sock.sendto(response, (self.broadcast, 68))
 
     def listen(self):
@@ -242,24 +251,19 @@ class DHCPD:
         while True:
             message, address = self.sock.recvfrom(1024)
             clientmac = struct.unpack('!28x6s', message[:34])
-            if self.mode_debug:
-                print '[DEBUG] Received message'
-                print '\t<--BEGIN MESSAGE-->\n\t{message}\n\t<--END MESSAGE-->'.format(message = repr(message))
+            self.logger.debug('Received message')
+            self.logger.debug('  <--BEGIN MESSAGE-->\n\t{message}\n\t<--END MESSAGE-->'.format(message = repr(message)))
             self.options = self.tlvParse(message[240:])
-            if self.mode_debug:
-                print '[DEBUG] Parsed received options'
-                print '\t<--BEGIN OPTIONS-->\n\t{options}\n\t<--END OPTIONS-->'.format(options = repr(self.options))
+            self.logger.debug('Parsed received options')
+            self.logger.debug('  <--BEGIN OPTIONS-->\n\t{options}\n\t<--END OPTIONS-->'.format(options = repr(self.options)))
             if not (60 in self.options and 'PXEClient' in self.options[60][0]) : continue
             type = ord(self.options[53][0]) #see RFC2131 page 10
             if type == 1:
-                if self.mode_debug:
-                    print '[DEBUG] Received DHCPOFFER'
+                self.logger.debug('Received DHCPOFFER')
                 self.dhcpOffer(message)
             elif type == 3 and address[0] == '0.0.0.0' and not self.mode_proxy:
-                if self.mode_debug:
-                    print '[DEBUG] Received DHCPACK'
+                self.logger.debug('Received DHCPACK')
                 self.dhcpAck(message)
             elif type == 3 and address[0] != '0.0.0.0' and self.mode_proxy:
-                if self.mode_debug:
-                    print '[DEBUG] Received DHCPACK'
+                self.logger.debug('Received DHCPACK')
                 self.dhcpAck(message)

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -7,6 +7,7 @@ This file contains classes and functions that implement the PyPXE HTTP service
 import socket
 import struct
 import os
+import logging
 
 class HTTPD:
     '''
@@ -19,6 +20,19 @@ class HTTPD:
         self.port = serverSettings.get('port', 80)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
         self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
+        self.logger =  serverSettings.get('logger', None)
+
+        # setup logger
+        if self.logger == None:
+            self.logger = logging.getLogger("HTTP")
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s %(name)s [%(levelname)s] %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+        if self.mode_debug:
+            self.logger.setLevel(logging.DEBUG)
+
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
@@ -29,18 +43,16 @@ class HTTPD:
         os.chdir (self.netbootDirectory)
         os.chroot ('.')
 
-        if self.mode_debug:
-            print 'NOTICE: HTTP server started in debug mode. HTTP server is using the following:'
-            print '\tHTTP Server IP: {}'.format(self.ip)
-            print '\tHTTP Server Port: {}'.format(self.port)
-            print '\tHTTP Network Boot Directory: {}'.format(self.netbootDirectory)
+        self.logger.debug('NOTICE: HTTP server started in debug mode. HTTP server is using the following:')
+        self.logger.debug('  HTTP Server IP: {}'.format(self.ip))
+        self.logger.debug('  HTTP Server Port: {}'.format(self.port))
+        self.logger.debug('  HTTP Network Boot Directory: {}'.format(self.netbootDirectory))
 
     def handleRequest(self, connection, addr):
         '''This method handles HTTP request'''
         request = connection.recv(1024)
-        if self.mode_debug:
-            print '[DEBUG] HTTP Recieved message from {addr}'.format(addr = repr(addr))
-            print '\t<--BEGIN MESSAGE-->\n\t{request}\n\t<--END MESSAGE-->'.format(request = repr(request))
+        self.logger.debug('HTTP Recieved message from {addr}'.format(addr = repr(addr)))
+        self.logger.debug('  <--BEGIN MESSAGE-->\n\t{request}\n\t<--END MESSAGE-->'.format(request = repr(request)))
         startline = request.split('\r\n')[0].split(' ')
         method = startline[0]
         target = startline[1]
@@ -54,28 +66,25 @@ class HTTPD:
         if status[:3] in ('404', '501'): #fail out
             connection.send(response)
             connection.close()
-            if self.mode_debug:
-                print '[DEBUG] HTTP Sending message to {addr}'.format(addr = repr(addr))
-                print '\t<--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response))
+            self.logger.debug('HTTP Sending message to {addr}'.format(addr = repr(addr)))
+            self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
             return
         response += 'Content-Length: %d\r\n' % os.path.getsize(target)
         response += '\r\n'
         if method == 'HEAD':
             connection.send(response)
             connection.close()
-            if self.mode_debug:
-                print '[DEBUG] HTTP Sending message to {addr}'.format(addr = repr(addr))
-                print '\t<--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response))
+            self.logger.debug('HTTP Sending message to {addr}'.format(addr = repr(addr)))
+            self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
             return
         handle = open(target)
         response += handle.read()
         handle.close()
         connection.send(response)
         connection.close()
-        if self.mode_debug:
-            print '[DEBUG] HTTP Sending message to {addr}'.format(addr = repr(addr))
-            print '\t<--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response))
-            print '\tHTTP File Sent - http://{target} -> {addr[0]}:{addr[1]}'.format(target = target, addr = addr)
+        self.logger.debug('HTTP Sending message to {addr}'.format(addr = repr(addr)))
+        self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
+        self.logger.debug('  HTTP File Sent - http://{target} -> {addr[0]}:{addr[1]}'.format(target = target, addr = addr))
 
     def listen(self):
         '''This method is the main loop that listens for requests'''

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -9,6 +9,7 @@ import struct
 import os
 import select
 import time
+import logging
 from collections import defaultdict
 
 class TFTPD:
@@ -21,15 +22,26 @@ class TFTPD:
         self.port = serverSettings.get('port', 69)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
         self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
+        self.logger = serverSettings.get('logger', None)
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
 
+        # setup logger
+        if self.logger == None:
+            self.logger = logging.getLogger("TFTP")
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
         if self.mode_debug:
-            print 'NOTICE: TFTP server started in debug mode. TFTP server is using the following:'
-            print '\tTFTP Server IP: {}'.format(self.ip)
-            print '\tTFTP Server Port: {}'.format(self.port)
-            print '\tTFTP Network Boot Directory: {}'.format(self.netbootDirectory)
+            self.logger.setLevel(logging.DEBUG)
+
+        self.logger.debug('NOTICE: TFTP server started in debug mode. TFTP server is using the following:')
+        self.logger.debug('  TFTP Server IP: {}'.format(self.ip))
+        self.logger.debug('TFTP Server Port: {}'.format(self.port))
+        self.logger.debug('  TFTP Network Boot Directory: {}'.format(self.netbootDirectory))
 
         #key is (address, port) pair
         self.ongoing = defaultdict(lambda: {'filename': '', 'handle': None, 'block': 1, 'blksize': 512, 'sock':None, 'timeout':float("inf"), 'retries':3})
@@ -57,8 +69,7 @@ class TFTPD:
         response =  struct.pack('!H', 5) #error code
         response += struct.pack('!H', 1) #file not found
         response += 'File Not Found'
-        if self.mode_debug:
-            print "[DEBUG] TFTP Sending 'File Not Found'"
+        self.logger.debug("TFTP Sending 'File Not Found'")
         self.sock.sendto(response, address)
 
     def sendBlock(self, address):
@@ -70,15 +81,13 @@ class TFTPD:
         response += struct.pack('!H', descriptor['block'] % 2 ** 16)
         data = descriptor['handle'].read(descriptor['blksize'])
         response += data
-        if self.mode_debug:
-            print '[DEBUG] TFTP Sending block {block}'.format(block = repr(descriptor['block']))
+        self.logger.debug('TFTP Sending block {block}'.format(block = repr(descriptor['block'])))
         descriptor['sock'].sendto(response, address)
         self.ongoing[address]['retries'] -= 1
         self.ongoing[address]['timeout'] = time.time()
         if len(data) != descriptor['blksize']:
             descriptor['handle'].close()
-            if self.mode_debug:
-                print '[DEBUG] TFTP File Sent - tftp://{filename} -> {address[0]}:{address[1]}'.format(filename = descriptor['filename'], address = address)
+            self.logger.debug('TFTP File Sent - tftp://{filename} -> {address[0]}:{address[1]}'.format(filename = descriptor['filename'], address = address))
             descriptor['sock'].close()
             self.ongoing.pop(address)
 
@@ -104,8 +113,8 @@ class TFTPD:
             self.ongoing[address]['blksize'] = int(options['blksize'])
         filesize = os.path.getsize(self.ongoing[address]['filename'])
         if filesize > (2**16 * self.ongoing[address]['blksize']):
-            print '\nWARNING: TFTP request too big, attempting transfer anyway.\n'
-            print '\tDetails: Filesize {filesize} is too big for blksize {blksize}.\n'.format(filesize = filesize, blksize = self.ongoing[address]['blksize'])
+            self.logger.warning('TFTP request too big, attempting transfer anyway.')
+            self.logger.warning('  Details: Filesize {filesize} is too big for blksize {blksize}.\n'.format(filesize = filesize, blksize = self.ongoing[address]['blksize']))
         if 'tsize' in options:
             response += 'tsize' + chr(0)
             response += str(filesize)
@@ -127,8 +136,7 @@ class TFTPD:
                 opcode = struct.unpack('!H', message[:2])[0]
                 message = message[2:]
                 if opcode == 1: #read the request
-                    if self.mode_debug:
-                        print '[DEBUG] TFTP receiving request'
+                    self.logger.debug('TFTP receiving request')
                     self.read(address, message)
                 if opcode == 4:
                      if self.ongoing.has_key(address):
@@ -140,7 +148,6 @@ class TFTPD:
             #Resent those that have timed out
             for i in self.ongoing:
                 if self.ongoing[i]['timeout']+5 < time.time() and self.ongoing[i]['retries']:
-                    print self.ongoing[i]['handle'].tell()
                     self.ongoing[i]['handle'].seek(-self.ongoing[i]['blksize'], 1)
                     self.sendBlock(i)
                 if not self.ongoing[i]['retries']:

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -18,31 +18,18 @@ class TFTPD:
     '''
     def __init__(self, **serverSettings):
         self.ip = serverSettings.get('ip', '0.0.0.0')
-        self.port = serverSettings.get('port', 79)
+        self.port = serverSettings.get('port', 69)
         self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
-        self.logger = serverSettings.get('logger', None)
-        self.mode_debug = serverSettings.get('mode_debug', False)
+        self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((self.ip, self.port))
 
-        if self.logger == None:
-            import logging
-            import logging.handlers
-            # setup logger
-            self.logger = logging.getLogger("tftp")
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
-            handler.setFormatter(formatter)
-            self.logger.addHandler(handler)
-
-            if self.mode_debug:
-                self.logger.setLevel(logging.DEBUG)
-
-        self.logger.debug('TFTP server started in debug mode. TFTP server is using the following:')
-        self.logger.debug('\tTFTP Server IP: {}'.format(self.ip))
-        self.logger.debug('\tTFTP Server Port: {}'.format(self.port))
-        self.logger.debug('\tTFTP Network Boot Directory: {}'.format(self.netbootDirectory))
+        if self.mode_debug:
+            print 'NOTICE: TFTP server started in debug mode. TFTP server is using the following:'
+            print '\tTFTP Server IP: {}'.format(self.ip)
+            print '\tTFTP Server Port: {}'.format(self.port)
+            print '\tTFTP Network Boot Directory: {}'.format(self.netbootDirectory)
 
         #key is (address, port) pair
         self.ongoing = defaultdict(lambda: {'filename': '', 'handle': None, 'block': 1, 'blksize': 512, 'sock':None, 'timeout':float("inf"), 'retries':3})
@@ -51,7 +38,6 @@ class TFTPD:
         # this simplifies target later as well as offers a slight security increase
         os.chdir (self.netbootDirectory)
         os.chroot ('.')
-
 
     def filename(self, message):
         '''
@@ -71,7 +57,8 @@ class TFTPD:
         response =  struct.pack('!H', 5) #error code
         response += struct.pack('!H', 1) #file not found
         response += 'File Not Found'
-        self.logger.debug("TFTP Sending 'File Not Found'")
+        if self.mode_debug:
+            print "[DEBUG] TFTP Sending 'File Not Found'"
         self.sock.sendto(response, address)
 
     def sendBlock(self, address):
@@ -83,13 +70,15 @@ class TFTPD:
         response += struct.pack('!H', descriptor['block'] % 2 ** 16)
         data = descriptor['handle'].read(descriptor['blksize'])
         response += data
-        self.logger.debug('TFTP Sending block {block}'.format(block = repr(descriptor['block'])))
+        if self.mode_debug:
+            print '[DEBUG] TFTP Sending block {block}'.format(block = repr(descriptor['block']))
         descriptor['sock'].sendto(response, address)
         self.ongoing[address]['retries'] -= 1
         self.ongoing[address]['timeout'] = time.time()
         if len(data) != descriptor['blksize']:
             descriptor['handle'].close()
-            self.logger.debug('TFTP File Sent - tftp://{filename} -> {address[0]}:{address[1]}'.format(filename = descriptor['filename'], address = address))
+            if self.mode_debug:
+                print '[DEBUG] TFTP File Sent - tftp://{filename} -> {address[0]}:{address[1]}'.format(filename = descriptor['filename'], address = address)
             descriptor['sock'].close()
             self.ongoing.pop(address)
 
@@ -100,13 +89,12 @@ class TFTPD:
                 file does not exist -> reply with error
         '''
         filename = self.filename(message)
-        self.logger.debug('Filename: %s' % filename)
         if not os.path.lexists(filename):
             self.notFound(address)
             return
         self.ongoing[address]['filename'] = filename
         self.ongoing[address]['handle'] = open(filename, 'r')
-        options = message.split(chr(0))[3: -1]
+        options = message.split(chr(0))[2: -1]
         options = dict(zip(options[0::2], options[1::2]))
         response = ''
         if 'blksize' in options:
@@ -116,8 +104,8 @@ class TFTPD:
             self.ongoing[address]['blksize'] = int(options['blksize'])
         filesize = os.path.getsize(self.ongoing[address]['filename'])
         if filesize > (2**16 * self.ongoing[address]['blksize']):
-            self.logger.warning('TFTP request too big, attempting transfer anyway.\n')
-            self.logger.debug('\tDetails: Filesize {filesize} is too big for blksize {blksize}.\n'.format(filesize = filesize, blksize = self.ongoing[address]['blksize']))
+            print '\nWARNING: TFTP request too big, attempting transfer anyway.\n'
+            print '\tDetails: Filesize {filesize} is too big for blksize {blksize}.\n'.format(filesize = filesize, blksize = self.ongoing[address]['blksize'])
         if 'tsize' in options:
             response += 'tsize' + chr(0)
             response += str(filesize)
@@ -139,7 +127,8 @@ class TFTPD:
                 opcode = struct.unpack('!H', message[:2])[0]
                 message = message[2:]
                 if opcode == 1: #read the request
-                    self.logger.debug('TFTP receiving request')
+                    if self.mode_debug:
+                        print '[DEBUG] TFTP receiving request'
                     self.read(address, message)
                 if opcode == 4:
                      if self.ongoing.has_key(address):
@@ -151,7 +140,7 @@ class TFTPD:
             #Resent those that have timed out
             for i in self.ongoing:
                 if self.ongoing[i]['timeout']+5 < time.time() and self.ongoing[i]['retries']:
-                    self.logger.debug(self.ongoing[i]['handle'].tell())
+                    print self.ongoing[i]['handle'].tell()
                     self.ongoing[i]['handle'].seek(-self.ongoing[i]['blksize'], 1)
                     self.sendBlock(i)
                 if not self.ongoing[i]['retries']:


### PR DESCRIPTION
This patch adds support for python [logging](https://docs.python.org/2/library/logging.html) module.
This makes PyPXE compatibile with software using the logging module.
This patch is backward compatible: you're not obliged to use logging in your project: each module can instantiate a local (StreamHandler](https://docs.python.org/2/library/logging.handlers.html#streamhandler) if no logger is received in the constructor.

--syslog and --syslog-port system options are added.