### PR TITLE
Portability Issues

### DIFF
--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -169,7 +169,7 @@ if __name__ == '__main__':
             # setup http logger
             http_logger = sys_logger.getChild("HTTP")
             sys_logger.info('Starting HTTP server...')
-            httpServer = http.HTTPD(mode_debug = ("http" in args.MODE_DEBUG.lower() or "all" in args.MODE_DEBUG.lower()), logger = http_logger, port = 8090)
+            httpServer = http.HTTPD(mode_debug = ("http" in args.MODE_DEBUG.lower() or "all" in args.MODE_DEBUG.lower()), logger = http_logger)
             httpd = threading.Thread(target = httpServer.listen)
             httpd.daemon = True
             httpd.start()

--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -18,7 +18,7 @@ from pypxe import http #PyPXE HTTP service
 JSON_CONFIG = ''
 
 #Default Network Boot File Directory
-NETBOOT_DIR = os.path.abspath(os.path.join(os.getcwd(), 'netboot'))
+NETBOOT_DIR = 'netboot'
 
 #Default PXE Boot File
 NETBOOT_FILE = ''
@@ -119,7 +119,7 @@ if __name__ == '__main__':
                 args.NETBOOT_FILE = 'boot.http.ipxe'
 
         #serve all files from one directory
-        os.chdir(args.NETBOOT_DIR)
+        os.chdir(os.path.abspath(args.NETBOOT_DIR))
         
         #make a list of running threads for each service
         runningServices = []

--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -37,9 +37,11 @@ DHCP_FILESERVER = '192.168.2.2'
 if __name__ == '__main__':
     try:
         #warn the user that they are starting PyPXE as non-root user
-        if os.getuid() != 0:
-            print '\nWARNING: Not root. Servers will probably fail to bind.\n'
-        
+        try:
+            if os.getuid() != 0:
+                print '\nWARNING: Not root. Servers will probably fail to bind.\n'
+        except AttributeError:
+            print '\nWARNING: Unable to check your user privileges'
         #
         # Define Command Line Arguments
         #

--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -18,7 +18,7 @@ from pypxe import http #PyPXE HTTP service
 JSON_CONFIG = ''
 
 #Default Network Boot File Directory
-NETBOOT_DIR = 'netboot'
+NETBOOT_DIR = os.path.abspath(os.path.join(os.getcwd(), 'netboot'))
 
 #Default PXE Boot File
 NETBOOT_FILE = ''
@@ -119,7 +119,7 @@ if __name__ == '__main__':
                 args.NETBOOT_FILE = 'boot.http.ipxe'
 
         #serve all files from one directory
-        os.chdir (args.NETBOOT_DIR)
+        os.chdir(args.NETBOOT_DIR)
         
         #make a list of running threads for each service
         runningServices = []

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -51,7 +51,7 @@ class HTTPD:
         os.chdir (self.netbootDirectory)
         try:
             os.chroot ('.')
-        except Exception, e:
+        except AttributeError:
             self.logger.warning("Cannot chroot in '{dir}', maybe os.chroot() unsupported by your platform ?".format(dir = self.netbootDirectory))
 
 
@@ -62,7 +62,7 @@ class HTTPD:
         self.logger.debug('  <--BEGIN MESSAGE-->\n\t{request}\n\t<--END MESSAGE-->'.format(request = repr(request)))
         startline = request.split('\r\n')[0].split(' ')
         method = startline[0]
-        target = os.path.abspath(self.netbootDirectory + os.sep + startline[1])
+        target = os.path.abspath(os.path.join(self.netbootDirectory, startline[1]))
 
         if not os.path.lexists(target) or not os.path.isfile(target):
             status = '404 Not Found'

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -64,7 +64,7 @@ class HTTPD:
         req_file = startline[1]
 
         # avoid directory traversal: strip all ../ and make it relative
-        target = os.path.normpath(os.sep + self.netbootDirectory + os.sep + req_file).lstrip(os.sep)
+        target = os.path.normpath(os.sep + os.getcwd() + os.sep + req_file).lstrip(os.sep)
 
         if not os.path.lexists(target) or not os.path.isfile(target):
             status = '404 Not Found'

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -38,15 +38,22 @@ class HTTPD:
         self.sock.bind((self.ip, self.port))
         self.sock.listen(1)
 
-        # Start in network boot file directory and then chroot, 
-        # this simplifies target later as well as offers a slight security increase
-        os.chdir (self.netbootDirectory)
-        os.chroot ('.')
+        self.chroot()
 
         self.logger.debug('NOTICE: HTTP server started in debug mode. HTTP server is using the following:')
         self.logger.debug('  HTTP Server IP: {}'.format(self.ip))
         self.logger.debug('  HTTP Server Port: {}'.format(self.port))
         self.logger.debug('  HTTP Network Boot Directory: {}'.format(self.netbootDirectory))
+
+    def chroot(self):
+        # Start in network boot file directory and then chroot, 
+        # this simplifies target later as well as offers a slight security increase
+        os.chdir (self.netbootDirectory)
+        try:
+            os.chroot ('.')
+        except Exception, e:
+            self.logger.warning("Cannot chroot in '{dir}', maybe os.chroot() unsupported by your platform ?".format(dir = self.netbootDirectory))
+
 
     def handleRequest(self, connection, addr):
         '''This method handles HTTP request'''
@@ -55,7 +62,8 @@ class HTTPD:
         self.logger.debug('  <--BEGIN MESSAGE-->\n\t{request}\n\t<--END MESSAGE-->'.format(request = repr(request)))
         startline = request.split('\r\n')[0].split(' ')
         method = startline[0]
-        target = startline[1]
+        target = os.path.abspath(self.netbootDirectory + os.sep + startline[1])
+
         if not os.path.lexists(target) or not os.path.isfile(target):
             status = '404 Not Found'
         elif method not in ('GET', 'HEAD'):

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -20,7 +20,7 @@ class TFTPD:
     def __init__(self, **serverSettings):
         self.ip = serverSettings.get('ip', '0.0.0.0')
         self.port = serverSettings.get('port', 69)
-        self.netbootDirectory = serverSettings.get('netbootDirectory', '.')
+        self.netbootDirectory = serverSettings.get('netbootDirectory',  os.getcwd())
         self.mode_debug = serverSettings.get('mode_debug', False) #debug mode
         self.logger = serverSettings.get('logger', None)
         self.default_retries = serverSettings.get('default_retries', 3)
@@ -131,7 +131,7 @@ class TFTPD:
             return
         req_file = self.filename(message)
         # avoid directory traversal: strip all ../ and make it relative
-        filename = os.path.normpath(os.sep + self.netbootDirectory + os.sep + req_file).lstrip(os.sep)
+        filename = os.path.normpath(os.sep + os.getcwd() + os.sep + req_file).lstrip(os.sep)
         
         if not os.path.lexists(filename):
             self.logger.debug("File '{filename}' not found, sending error message to the client".format(filename = filename) )

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -130,7 +130,9 @@ class TFTPD:
             self.tftpError(address, 5, 'Mode {mode} not supported'.format(mode = mode))
             return
         req_file = self.filename(message)
-        filename = os.path.abspath(os.path.join(self.netbootDirectory, req_file))
+        # avoid directory traversal: strip all ../ and make it relative
+        filename = os.path.normpath(os.sep + self.netbootDirectory + os.sep + req_file).lstrip(os.sep)
+        
         if not os.path.lexists(filename):
             self.logger.debug("File '{filename}' not found, sending error message to the client".format(filename = filename) )
             self.tftpError(address, 1, 'File Not Found')

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -56,7 +56,7 @@ class TFTPD:
         os.chdir (self.netbootDirectory)
         try:
             os.chroot ('.')
-        except Exception, e:
+        except AttributeError:
             self.logger.warning("Cannot chroot in '{dir}', maybe os.chroot() unsupported by your platform ?".format(dir = self.netbootDirectory))
 
     def filename(self, message):
@@ -130,7 +130,7 @@ class TFTPD:
             self.tftpError(address, 5, 'Mode {mode} not supported'.format(mode = mode))
             return
         req_file = self.filename(message)
-        filename = os.path.abspath(self.netbootDirectory + os.sep + req_file)
+        filename = os.path.abspath(os.path.join(self.netbootDirectory, req_file))
         if not os.path.lexists(filename):
             self.logger.debug("File '{filename}' not found, sending error message to the client".format(filename = filename) )
             self.tftpError(address, 1, 'File Not Found')


### PR DESCRIPTION
* moved os.chroot() in self.chroot() so one can overwrite the method is os.chroot() isn't supported
* cached the os.getuid() exception
* used the absolute file path for TFTP / HTTP request handling