### PR TITLE
Multiple Cleanup Items

### DIFF
--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
         args = parser.parse_args()
         if args.JSON_CONFIG:
             try:
-                config = open(args.JSON_CONFIG)
+                config = open(args.JSON_CONFIG, 'rb')
             except IOError:
                 sys.exit("Failed to open %s" % args.JSON_CONFIG)
             try:
@@ -94,14 +94,14 @@ if __name__ == '__main__':
             handler = logging.handlers.SysLogHandler(address = (args.SYSLOG_SERVER, int(args.SYSLOG_PORT)))
         else:
             handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)s [%(levelname)s] %(message)s')
+        formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s %(message)s')
         handler.setFormatter(formatter)
         sys_logger.addHandler(handler)
         sys_logger.setLevel(logging.INFO)
 
         #pass warning to user regarding starting HTTP server without iPXE
         if args.USE_HTTP and not args.USE_IPXE and not args.USE_DHCP:
-            sys_logger.warning('WARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
+            sys_logger.warning('HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
         
         #if the argument was pased to enabled ProxyDHCP then enable the DHCP server
         if args.DHCP_MODE_PROXY:

--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -16,10 +16,10 @@ class OutOfLeasesError(Exception):
 
 class DHCPD:
     '''
-        This class implements a DHCP Server, limited to pxe options,
-        where the subnet /24 is hard coded. Implemented from RFC2131,
-        RFC2132, https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol
-        and http://www.pix.net/software/pxeboot/archive/pxespec.pdf
+        This class implements a DHCP Server, limited to pxe options.
+        Implemented from RFC2131, RFC2132,
+        https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol and
+        http://www.pix.net/software/pxeboot/archive/pxespec.pdf
     '''
     def __init__(self, **serverSettings):
         
@@ -57,7 +57,7 @@ class DHCPD:
             self.logger.setLevel(logging.DEBUG)
 
         if self.http and not self.ipxe:
-            self.logger.warning('WARNING: HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
+            self.logger.warning('HTTP selected but iPXE disabled. PXE ROM must support HTTP requests.')
         if self.ipxe and self.http:
             self.filename = 'http://{fileserver}/{filename}'.format(fileserver = self.fileserver, filename = self.filename)
         if self.ipxe and not self.http:
@@ -66,15 +66,18 @@ class DHCPD:
         self.logger.debug('NOTICE: DHCP server started in debug mode. DHCP server is using the following:')
         self.logger.debug('  DHCP Server IP: {}'.format(self.ip))
         self.logger.debug('  DHCP Server Port: {}'.format(self.port))
-        self.logger.debug('  DHCP Lease Range: {} - {}'.format(self.offerfrom, self.offerto))
-        self.logger.debug('  DHCP Subnet Mask: {}'.format(self.subnetmask))
-        self.logger.debug('  DHCP Router: {}'.format(self.router))
-        self.logger.debug('  DHCP DNS Server: {}'.format(self.dnsserver))
-        self.logger.debug('  DHCP Broadcast Address: {}'.format(self.broadcast))
+
+        if not self.mode_proxy
+            self.logger.debug('  DHCP Lease Range: {} - {}'.format(self.offerfrom, self.offerto))
+            self.logger.debug('  DHCP Subnet Mask: {}'.format(self.subnetmask))
+            self.logger.debug('  DHCP Router: {}'.format(self.router))
+            self.logger.debug('  DHCP DNS Server: {}'.format(self.dnsserver))
+            self.logger.debug('  DHCP Broadcast Address: {}'.format(self.broadcast))
+
         self.logger.debug('  DHCP File Server IP: {}'.format(self.fileserver))
         self.logger.debug('  DHCP File Name: {}'.format(self.filename))
         self.logger.debug('  ProxyDHCP Mode: {}'.format(self.mode_proxy))
-        self.logger.debug('  tUsing iPXE: {}'.format(self.ipxe))
+        self.logger.debug('  Using iPXE: {}'.format(self.ipxe))
         self.logger.debug('  Using HTTP Server: {}'.format(self.http))
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -128,13 +131,13 @@ class DHCPD:
         '''
         ret = {}
         while(raw):
-            tag = struct.unpack('B', raw[0])[0]
+            [tag] = struct.unpack('B', raw[0])
             if tag == 0:  #padding
                 raw = raw[1:]
                 continue
             if tag == 255:  #end marker
                 break
-            length = struct.unpack('B', raw[1])[0]
+            [length] = struct.unpack('B', raw[1])
             value = raw[2:2 + length]
             raw = raw[2 + length:]
             if tag in ret:
@@ -208,18 +211,18 @@ class DHCPD:
             #http://www.syslinux.org/wiki/index.php/PXELINUX#UEFI
             if 93 in self.options and not self.forcefilename:
                 [arch] = struct.unpack("!H", self.options[93][0])
-                if arch == 6: #EFI IA32
+                if arch == 0: #BIOS/default
+                    response += self.tlvEncode(67, "pxelinux.0" + chr(0))
+                elif arch == 6: #EFI IA32
                     response += self.tlvEncode(67, "syslinux.efi32" + chr(0))
                 elif arch == 7: #EFI BC, x86-64 according to link above
                     response += self.tlvEncode(67, "syslinux.efi64" + chr(0))
                 elif arch == 9: #EFI x86-64
                     response += self.tlvEncode(67, "syslinux.efi64" + chr(0))
-                if arch == 0: #BIOS/default
-                    response += self.tlvEncode(67, "pxelinux.0" + chr(0))
             else:
                 response += self.tlvEncode(67, self.filename + chr(0))
         else:
-            response += self.tlvEncode(67, '/chainload.kpxe' + chr(0)) #chainload iPXE
+            response += self.tlvEncode(67, 'chainload.kpxe' + chr(0)) #chainload iPXE
             if opt53 == 5: #ACK
                 self.leases[clientmac]['ipxe'] = False
         if self.mode_proxy:
@@ -253,10 +256,10 @@ class DHCPD:
     def validateReq(self):
         # client request is valid only if contains Vendor-Class = PXEClient
         if 60 in self.options and 'PXEClient' in self.options[60][0]:
-            self.logger.debug('Valid client request received')
+            self.logger.debug('PXE client request received')
             return True
         if self.mode_debug:
-            self.logger.debug('Invalid client request received')
+            self.logger.debug('Non-PXE client request received')
         return False
 
     def listen(self):

--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -67,7 +67,7 @@ class DHCPD:
         self.logger.debug('  DHCP Server IP: {}'.format(self.ip))
         self.logger.debug('  DHCP Server Port: {}'.format(self.port))
 
-        if not self.mode_proxy
+        if not self.mode_proxy:
             self.logger.debug('  DHCP Lease Range: {} - {}'.format(self.offerfrom, self.offerto))
             self.logger.debug('  DHCP Subnet Mask: {}'.format(self.subnetmask))
             self.logger.debug('  DHCP Router: {}'.format(self.router))

--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -49,7 +49,7 @@ class DHCPD:
         if self.logger == None:
             self.logger = logging.getLogger("DHCP")
             handler = logging.StreamHandler()
-            formatter = logging.Formatter('%(asctime)s %(name)s [%(levelname)s] %(message)s')
+            formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s %(message)s')
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
 
@@ -171,7 +171,7 @@ class DHCPD:
                 offer = self.nextIP()
                 self.leases[clientmac]['ip'] = offer
                 self.leases[clientmac]['expire'] = time() + 86400
-                self.logger.debug('New DHCP Assignment - MAC: {MAC} -> IP: {IP}'.format(MAC = self.printMAC(clientmac), IP = self.leases[clientmac]['ip']))
+                self.logger.debug('New Assignment - MAC: {MAC} -> IP: {IP}'.format(MAC = self.printMAC(clientmac), IP = self.leases[clientmac]['ip']))
             response += socket.inet_aton(offer) #yiaddr
         else:
             response += socket.inet_aton('0.0.0.0')
@@ -280,7 +280,7 @@ class DHCPD:
                 try:
                     self.dhcpOffer(message)
                 except OutOfLeasesError:
-                    self.logger.critical("Ran out of DHCP leases")
+                    self.logger.critical("Ran out of leases")
             elif type == 3 and address[0] == '0.0.0.0' and not self.mode_proxy:
                 self.logger.debug('Received DHCPACK')
                 self.dhcpAck(message)

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -38,7 +38,7 @@ class HTTPD:
         self.sock.bind((self.ip, self.port))
         self.sock.listen(1)
 
-        # Start in network boot file directory and then chroot, 
+        # Start in network boot file directory and then chroot,
         # this simplifies target later as well as offers a slight security increase
         os.chdir (self.netbootDirectory)
         os.chroot ('.')
@@ -51,11 +51,9 @@ class HTTPD:
     def handleRequest(self, connection, addr):
         '''This method handles HTTP request'''
         request = connection.recv(1024)
-        self.logger.debug('HTTP Recieved message from {addr}'.format(addr = repr(addr)))
+        self.logger.debug('Recieved message from {addr}'.format(addr = addr))
         self.logger.debug('  <--BEGIN MESSAGE-->\n\t{request}\n\t<--END MESSAGE-->'.format(request = repr(request)))
-        startline = request.split('\r\n')[0].split(' ')
-        method = startline[0]
-        target = startline[1]
+        method, target, version = request.split('\r\n')[0].split(' ')
         if not os.path.lexists(target) or not os.path.isfile(target):
             status = '404 Not Found'
         elif method not in ('GET', 'HEAD'):
@@ -66,15 +64,15 @@ class HTTPD:
         if status[:3] in ('404', '501'): #fail out
             connection.send(response)
             connection.close()
-            self.logger.debug('HTTP Sending message to {addr}'.format(addr = repr(addr)))
+            self.logger.debug('Sending message to {addr}'.format(addr = repr(addr)))
             self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
             return
-        response += 'Content-Length: %d\r\n' % os.path.getsize(target)
+        response += 'Content-Length: {}\r\n'.format(os.path.getsize(target))
         response += '\r\n'
         if method == 'HEAD':
             connection.send(response)
             connection.close()
-            self.logger.debug('HTTP Sending message to {addr}'.format(addr = repr(addr)))
+            self.logger.debug('Sending message to {addr}'.format(addr = repr(addr)))
             self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
             return
         handle = open(target)
@@ -82,9 +80,9 @@ class HTTPD:
         handle.close()
         connection.send(response)
         connection.close()
-        self.logger.debug('HTTP Sending message to {addr}'.format(addr = repr(addr)))
+        self.logger.debug('Sending message to {addr}'.format(addr = repr(addr)))
         self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
-        self.logger.debug('  HTTP File Sent - http://{target} -> {addr[0]}:{addr[1]}'.format(target = target, addr = addr))
+        self.logger.debug('  File Sent - http://{target} -> {addr}'.format(target = target, addr = addr))
 
     def listen(self):
         '''This method is the main loop that listens for requests'''

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -82,7 +82,7 @@ class HTTPD:
         connection.close()
         self.logger.debug('Sending message to {addr}'.format(addr = repr(addr)))
         self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
-        self.logger.debug('  File Sent - http://{target} -> {addr}'.format(target = target, addr = addr))
+        self.logger.debug('File Sent - http://{target} -> {addr}'.format(target = target, addr = addr))
 
     def listen(self):
         '''This method is the main loop that listens for requests'''

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -26,7 +26,7 @@ class HTTPD:
         if self.logger == None:
             self.logger = logging.getLogger("HTTP")
             handler = logging.StreamHandler()
-            formatter = logging.Formatter('%(asctime)s %(name)s [%(levelname)s] %(message)s')
+            formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s %(message)s')
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
 
@@ -75,7 +75,7 @@ class HTTPD:
             self.logger.debug('Sending message to {addr}'.format(addr = repr(addr)))
             self.logger.debug('  <--BEING MESSAGE-->\n\t{response}\n\t<--END MESSAGE-->'.format(response = repr(response)))
             return
-        handle = open(target)
+        handle = open(target, 'rb')
         response += handle.read()
         handle.close()
         connection.send(response)

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -28,7 +28,7 @@ class Client:
         self.ip = parent.ip
         self.message, self.address = mainsock.recvfrom(1024)
         self.logger = parent.logger.getChild('Client.{}'.format(self.address))
-        self.logger.debug('TFTP recieving request')
+        self.logger.debug('Recieving request')
         self.retries = self.default_retries
         self.block = 1
         self.blksize = 512
@@ -94,7 +94,7 @@ class Client:
         self.lastblock = math.ceil(self.filesize / float(self.blksize))
         self.tsize = True if 'tsize' in options else False
         if self.filesize > (2**16)*self.blksize:
-            self.logger.warning('TFTP request too big, attempting transfer anyway.')
+            self.logger.warning('Request too big, attempting transfer anyway.')
             self.logger.debug('  Details: Filesize %s is too big for blksize %s.\n', self.filesize, self.blksize)
 
         if len(options):
@@ -161,7 +161,7 @@ class Client:
         response += message
         response += chr(0)
         self.sock.sendto(response, self.address)
-        self.logger.debug("TFTP Sending '%d: %s' %s", code, message, filename)
+        self.logger.debug("Sending '%d: %s' %s", code, message, filename)
 
     def complete(self):
         '''When we've finished sending a file, we need to close it, the
@@ -217,7 +217,7 @@ class TFTPD:
         if self.logger == None:
             self.logger = logging.getLogger("TFTP")
             handler = logging.StreamHandler()
-            formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+            formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s')
             handler.setFormatter(formatter)
             self.logger.addHandler(handler)
 
@@ -226,7 +226,7 @@ class TFTPD:
 
         self.logger.debug('NOTICE: TFTP server started in debug mode. TFTP server is using the following:')
         self.logger.debug('  TFTP Server IP: {}'.format(self.ip))
-        self.logger.debug('TFTP Server Port: {}'.format(self.port))
+        self.logger.debug('  TFTP Server Port: {}'.format(self.port))
         self.logger.debug('  TFTP Network Boot Directory: {}'.format(self.netbootDirectory))
 
         self.ongoing = []


### PR DESCRIPTION
I've done most of the non-intrusive items from #59. Below is the copied list of items from #59 which are fixed in this PR.

# Bugs
## pypxe-server (1/3)
 - [x] __BUG__ `Using iPXE:` debug message has a `t` before it from when it was `\t`

## DHCP (1/1)
 - [x] __BUG__:  DHCP `craftOptions` for iPXE chainload we shouldn't have a leading `/` to match everything else

## Misc (1/3)
 - [x] __BUG__ xref #73 all `open`s should have mode `b` as well. _(Note, this is a good idea even without Windows as a target)_


# Cleanup
## Logging (2/4)
 - [x] We have lines like `self.logger.debug('  HTTP...`. We don't necessarily need to specify HTTP as we have `%(name)s` in the logger format string.
 - [x] For the logging format, `%(name)s` and `[%(levelname)s]` should probably be swapped, to more strongly associate message with source.

## DHCP (5/8)
 - [x] DHCP sometimes logs `Invalid client request received` vs. `Valid client request received`, I don't think this is totally true. The client request isn't invalid, it's just not a PXE request. This should probably be changed to reflect this.
 - [x] DHCPD ~L57 `if self.http and not self.ipxe` "WARNING" is unnecessary as we're already logging to warning
 - [x] DHCPD `tlvParse` `struct.unpack` lines are cleaner as e.g. `[tag] = struct.unpack('B', raw[0])`
 - [x] DHCPD `craftOptions` `if arch == 0:` should be `elif`, also possibly first to order by arch ID
 - [x] We don't need to print out all the dhcp default settings when we're using `dhcp-proxy`

## HTTP (4/5)
 - [x] The `HTTP File Sent` debug log line at the end of HTTPD has an inconsistent addr output to the rest of the project. Should just be `{}`
 - [x] `HTTP Recieved` debug at the top of `handleRequest` does an unneccessary `repr` on the address
 - [x] `HTTPD.handleRequest`, the lines assigning `startline`, `method` and `target` can be inlined and use tuple unpacking instead. The RFC allows this.
 - [x] `Content-Length` formatting -> `{}` and `.format()`
