### PR TITLE
Minor Bug Fixes for v1.6

### DIFF
--- a/pypxe-server.py
+++ b/pypxe-server.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
         if args.NBD_WRITE and not args.NBD_COW:
             sys_logger.warning('NBD Write enabled but copy-on-write is not. Multiple clients may cause corruption')
 
-        if args.NBD_COWINMEM or args.NBD_COPYTORAM:
+        if args.NBD_COW_IN_MEM or args.NBD_COPY_TO_RAM:
             sys_logger.warning('NBD cowinmem and copytoram can cause high RAM usage')
 
         #serve all files from one directory

--- a/pypxe/nbd/writes.py
+++ b/pypxe/nbd/writes.py
@@ -83,7 +83,7 @@ class DiskCOW(COW):
         self.addr = addr
         self.imagefd = imagefd
         self.seek_lock = seek_lock
-        self.logger = logger.get_child('FS')
+        self.logger = logger.getChild('FS')
         self.logger.debug('Copy-On-Write for {addr} in PyPXE_NBD_COW_{addr[0]}_{addr[1]}'.format(addr = addr))
 
         # never want readonly cow, also definately creating file
@@ -97,7 +97,7 @@ class MemCOW(COW):
         self.addr = addr
         self.imagefd = imagefd
         self.seek_lock = seek_lock
-        self.logger = logger.get_child('FS')
+        self.logger = logger.getChild('FS')
         self.logger.debug('Copy-On-Write for {0} in Memory'.format(addr))
 
         # BytesIO looks exactly the same as a file, perfect for in memory disk
@@ -111,7 +111,7 @@ class RW:
         self.addr = addr
         self.seek_lock = seek_lock
         self.imagefd = imagefd
-        self.logger = logger.get_child('FS')
+        self.logger = logger.getChild('FS')
         self.logger.debug('File for {0}'.format(addr))
 
     def read(self, offset, length):


### PR DESCRIPTION
Fixes the following:

* Argument variable name change was not global
* `get_child` in nbd writes.py was wrong

With the initial debug logging block, there are a lot of lines that duplicate the service name in the log format string and the actual log message. For example:
```
2015-05-12 17:30:51,190 [DEBUG] PyPXE.TFTP TFTP Server IP: 0.0.0.0
2015-05-12 17:30:51,190 [DEBUG] PyPXE.TFTP TFTP Server Port: 69
2015-05-12 17:30:51,190 [DEBUG] PyPXE.TFTP TFTP Network Boot Directory: .
```
Should we remove the second `TFTP`, as it is already present in the logging namespace?