### PR TITLE
Only Increment Wrap after Going Half-way Through

### DIFF
--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -34,7 +34,8 @@ class Client:
         self.dead = False
         self.fh = None
         self.filename = ''
-        self.wrap = -1
+        self.wrap = 0
+        self.arm_wrap = False
 
         # message from the main socket
         self.handle()
@@ -197,8 +198,11 @@ class Client:
             self.newRequest()
         elif opcode == 4:
             [block] = struct.unpack('!H', self.message[2:4])
-            if block == 0:
+            if block == 0 and self.arm_wrap:
                 self.wrap += 1
+                self.arm_wrap = False
+            if block == 32768:
+                self.arm_wrap = True
             if block < self.block % 65536:
                 self.logger.warning('Ignoring duplicated ACK received for block {0}'.format(self.block))
             elif block > self.block % 65536:


### PR DESCRIPTION
I realized last night that duplicate acks for block 0 would incorrectly increase the wrap count. This makes it only increment the wrap after having gone half way through the sequence space. I've tested this against the tftp client in Tiny Core, FreeBSD, iPXE, and pxelinux without problems.

This is a much smaller bug than psychomario/PyPXE#95 since it would only occur on duplicate acks of block 0.