### PR TITLE
Always Seek to Correct Block

### DIFF
--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -50,6 +50,7 @@ class Client:
             Sends the next block of data, setting the timeout and retry
             variables accordingly.
         '''
+        self.fh.seek(self.blksize * (self.block - 1))
         data = self.fh.read(self.blksize)
         # opcode 3 == DATA, wraparound block number
         response = struct.pack('!HH', 3, self.block % 65536)


### PR DESCRIPTION
Always seek to the block we want to read.

I don't think there is any unneccessary overhead as `.seek()` doesn't actually read the file, just moves the `.read()` pointer.

Fixes #98