### PR TITLE
Added setuptools script. Refactored CLI entry point.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 *.pyc
+*.egg-info
+*.egg
+*.EGG
+*.EGG-INFO
+build
+build-win32
+develop-eggs
+eggs
+fake-eggs
+parts
+dist
+*.pyo
+*.tmp*
+*.swp

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -57,7 +57,7 @@ The PyPXE library provides the following services for the purpose of creating a 
 * `from pypxe import http` or `import pypxe.http` imports the HTTP service
 * `from pypxe import nbd` or `import pypxe.nbd` imports the NBD service
 
-**See [`pypxe-server.py`](pypxe-server.py) in the root of the repo for example usage on how to call, define, and setup the services.** When running any Python script that uses these classes, it should be run as a user with root privileges as they bind to interfaces and without root privileges the services will most likely fail to bind properly.
+**See [`pypxe/server.py`](pypxe.server) for example usage on how to call, define, and setup the services.** When running any Python script that uses these classes, it should be run as a user with root privileges as they bind to interfaces and without root privileges the services will most likely fail to bind properly.
 
 ## TFTP Server `pypxe.tftp`
 
@@ -172,5 +172,5 @@ The NBD server class, __`NBD()`__, is constructed with the following __keyword a
 
 ## Additional Information
 * The function `chr(0)` is used in multiple places throughout the servers. This denotes a `NULL` byte, or `\x00`
-* Python 2.6 does not include the `argparse` module, it is included in the standard library as of 2.7 and newer. The `argparse` module is required to take in command line arguments and `pypxe-server.py` will not run without it.
+* Python 2.6 does not include the `argparse` module, it is included in the standard library as of 2.7 and newer. The `argparse` module is required to take in command line arguments and `pypxe.server` will not run without it.
 * The TFTP server currently does not support transfer of large files, this is a known issue (see #35). Instead of using TFTP to transfer large files (roughly 33MB or greater) it is recommended that you use the HTTP server to do so. iPXE supports direct boot from HTTP and certain kernels (once you've booted into `pxelinux.0` via TFTP) support fetching files via HTTP as well.

--- a/README.md
+++ b/README.md
@@ -17,26 +17,26 @@ import pypxe.tftp
 For more information on how each service works and how to manipulate them, see  [`DOCUMENTATION.md`](DOCUMENTATION.md).
 
 ### QuickStart
-`pypxe-server.py` uses all three services in combination with the option of enabling/disabling them individually while also setting some options. Edit the `pypxe-server.py` settings to your preferred settings or run with `--help` or `-h` to see what command line arguments you can pass. Treat the provided `netboot` directory as `tftpboot` that you would typically see on a TFTP server, put all of your network-bootable files in there and setup your menu(s) in `netboot/pxelinux.cfg/default`.
+`pypxe.server` uses all three services in combination with the option of enabling/disabling them individually while also setting some options. Run `pypxe.server` with `--help` or `-h` to see what command line arguments you can pass. Treat the provided `netboot` directory as `tftpboot` that you would typically see on a TFTP server, put all of your network-bootable files in there and setup your menu(s) in `netboot/pxelinux.cfg/default`.
 
-**Note:** Python 2.6 does not include the `argparse` module, it is included in the standard library as of 2.7 and newer. The `argparse` module is required to take in command line arguments and `pypxe-server.py` will not run without it.
+**Note:** Python 2.6 does not include the `argparse` module, it is included in the standard library as of 2.7 and newer. The `argparse` module is required to take in command line arguments and `pypxe.server` will not run without it.
 
 Simply run the following command and you will have an out-of-the-box PXE-bootable server that runs TFTP and serves files out of the `netboot` directory!
 ```bash
-$ sudo python pypxe-server.py
+$ sudo python -m pypxe.server
 ```
 If you require the ability to handle DHCP PXE requests then you can either enable the built-in DHCP server (after configuring, of course)...
 ```bash
-$ sudo python pypxe-server.py --dhcp
+$ sudo python -m pypxe.server --dhcp
 ```
-...or start `pypxe-server.py` in ProxyDHCP mode rather than a full DHCP server to prevent DHCP conflicts on your network...
+...or start `pypxe.server` in ProxyDHCP mode rather than a full DHCP server to prevent DHCP conflicts on your network...
 ```bash
-$ sudo python pypxe-server.py --dhcp-proxy
+$ sudo python -m pypxe.server --dhcp-proxy
 ```
 
 #### PyPXE Server Arguments
 
-The following are arguments that can be passed to `pypxe-server.py` when running from the command line:
+The following are arguments that can be passed to `pypxe.server` when running from the command line:
 
 ##### Main Arguments
 

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -17,6 +17,7 @@ from pypxe import dhcp # PyPXE DHCP service
 from pypxe import http # PyPXE HTTP service
 from pypxe import nbd  # PyPXE NBD service
 
+args = None
 # default settings
 SETTINGS = {'NETBOOT_DIR':'netboot',
             'NETBOOT_FILE':'',
@@ -114,7 +115,8 @@ def do_verbose(service):
             or 'all' in args.MODE_VERBOSE.lower())
             and '-{0}'.format(service) not in args.MODE_VERBOSE.lower())
 
-if __name__ == '__main__':
+def main():
+    global SETTINGS, args
     try:
         # warn the user that they are starting PyPXE as non-root user
         if os.getuid() != 0:
@@ -285,3 +287,6 @@ if __name__ == '__main__':
 
     except KeyboardInterrupt:
         sys.exit('\nShutting down PyPXE...\n')
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+from sys import version_info
+
+deps = []
+
+# require argparse on Python <2.7 and <3.2
+if (version_info[0] == 2 and version_info[1] < 7) or \
+   (version_info[0] == 3 and version_info[1] < 2):
+    deps.append("argparse")
+
+setup(name='PyPXE',
+      version='1.6',
+      description='Pure Python2 PXE (DHCP-(Proxy)/TFTP/HTTP/NBD) Server',
+      url='https://github.com/psychomario/PyPXE',
+      license='MIT',
+      packages=find_packages(),
+      install_requires=deps,
+      entry_points={
+          'console_scripts': ['pypxe=pypxe.server:main']
+      }
+)

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 
 from setuptools import setup, find_packages
-from sys import version_info
+from sys import version_info, exit
 
 deps = []
 
-# require argparse on Python <2.7 and <3.2
-if (version_info[0] == 2 and version_info[1] < 7) or \
-   (version_info[0] == 3 and version_info[1] < 2):
+# Python 3 unsupported
+if version_info >= (3,):
+    print "Sorry, PyPXE doesn't support Python 3."
+    exit(1)
+
+# require argparse on Python <2.7
+if version_info[0] == 2 and version_info[1] < 7:
     deps.append("argparse")
 
 setup(name='PyPXE',


### PR DESCRIPTION
Moved `pypxe-server.py` to be `pypxe.server`, and made modifications required for that to work. Added a `setuptools` install script. Added relevant `.gitignore` bits for that.

    [root@icb:~] # cd PyPXE-icb
    [root@icb:~/PyPXE-icb] # python setup.py install
    running install
    running bdist_egg
    running egg_info
    writing PyPXE.egg-info/PKG-INFO
    writing top-level names to PyPXE.egg-info/top_level.txt
    writing dependency_links to PyPXE.egg-info/dependency_links.txt
    writing entry points to PyPXE.egg-info/entry_points.txt
    reading manifest file 'PyPXE.egg-info/SOURCES.txt'
    writing manifest file 'PyPXE.egg-info/SOURCES.txt'
    installing library code to build/bdist.freebsd-10.1-RELEASE-amd64/egg
    running install_lib
    running build_py
    creating build/bdist.freebsd-10.1-RELEASE-amd64/egg
    creating build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe
    copying build/lib/pypxe/dhcp.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe
    creating build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd
    copying build/lib/pypxe/nbd/nbd.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd
    copying build/lib/pypxe/nbd/writes.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd
    copying build/lib/pypxe/nbd/__init__.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd
    copying build/lib/pypxe/__init__.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe
    copying build/lib/pypxe/tftp.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe
    copying build/lib/pypxe/http.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe
    copying build/lib/pypxe/server.py -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/dhcp.py to dhcp.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd/nbd.py to nbd.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd/writes.py to writes.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/nbd/__init__.py to __init__.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/__init__.py to __init__.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/tftp.py to tftp.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/http.py to http.pyc
    byte-compiling build/bdist.freebsd-10.1-RELEASE-amd64/egg/pypxe/server.py to server.pyc
    creating build/bdist.freebsd-10.1-RELEASE-amd64/egg/EGG-INFO
    copying PyPXE.egg-info/PKG-INFO -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/EGG-INFO
    copying PyPXE.egg-info/SOURCES.txt -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/EGG-INFO
    copying PyPXE.egg-info/dependency_links.txt -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/EGG-INFO
    copying PyPXE.egg-info/entry_points.txt -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/EGG-INFO
    copying PyPXE.egg-info/top_level.txt -> build/bdist.freebsd-10.1-RELEASE-amd64/egg/EGG-INFO
    zip_safe flag not set; analyzing archive contents...
    creating 'dist/PyPXE-1.6-py2.7.egg' and adding 'build/bdist.freebsd-10.1-RELEASE-amd64/egg' to it
    removing 'build/bdist.freebsd-10.1-RELEASE-amd64/egg' (and everything under it)
    Processing PyPXE-1.6-py2.7.egg
    Removing /usr/local/lib/python2.7/site-packages/PyPXE-1.6-py2.7.egg
    Copying PyPXE-1.6-py2.7.egg to /usr/local/lib/python2.7/site-packages
    PyPXE 1.6 is already the active version in easy-install.pth
    Installing pypxe script to /usr/local/bin
    
    Installed /usr/local/lib/python2.7/site-packages/PyPXE-1.6-py2.7.egg
    Processing dependencies for PyPXE==1.6
    Finished processing dependencies for PyPXE==1.6
    [root@icb:~/PyPXE-icb] # cd ~/pxe
    [root@icb:~/pxe] # python -m pypxe.server
    2015-05-19 20:51:48,495 [INFO] PyPXE Starting TFTP server...
    2015-05-19 20:51:48,496 [INFO] PyPXE PyPXE successfully initialized and running!
    ^C
    Shutting down PyPXE...
    
    [root@icb:~/pxe] 1 # pypxe
    2015-05-19 20:51:54,087 [INFO] PyPXE Starting TFTP server...
    2015-05-19 20:51:54,087 [INFO] PyPXE PyPXE successfully initialized and running!
    ^C
    Shutting down PyPXE...
    
    [root@icb:~/pxe] 1 #
