### PR TITLE
Removed os.chroot() and replaced with proper path traversal detection

### DIFF
--- a/pypxe/helpers.py
+++ b/pypxe/helpers.py
@@ -1,0 +1,26 @@
+import os.path
+
+class PathTraversalException(Exception):
+    pass
+
+def normalize_path(base, filename):
+    """Join and normalize a base path and filename.
+
+   `base` may be relative, in which case it's converted to absolute.
+
+    Args:
+        base (str): Base path
+        filename (str): Filename (optionally including path relative to base)
+
+    Returns:
+        str: The joined and normalized path
+
+    Raises:
+        PathTraversalException: if an attempt to escape the base path is detected
+    """
+    abs_path = os.path.abspath(base)
+    joined = os.path.join(abs_path, filename)
+    normalized = os.path.normpath(joined)
+    if normalized.startswith(os.path.join(abs_path, '')):
+        return normalized
+    raise PathTraversalException("Path Traversal detected")

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -190,9 +190,6 @@ def main():
         if args.NBD_COW_IN_MEM or args.NBD_COPY_TO_RAM:
             sys_logger.warning('NBD cowinmem and copytoram can cause high RAM usage')
 
-        #serve all files from one directory
-        os.chdir (args.NETBOOT_DIR)
-
         # make a list of running threads for each service
         running_services = []
 
@@ -204,7 +201,7 @@ def main():
             sys_logger.info('Starting TFTP server...')
 
             # setup the thread
-            tftp_server = tftp.TFTPD(mode_debug = do_debug('tftp'), mode_verbose = do_verbose('tftp'), logger = tftp_logger)
+            tftp_server = tftp.TFTPD(mode_debug = do_debug('tftp'), mode_verbose = do_verbose('tftp'), logger = tftp_logger, netboot_directory = args.NETBOOT_DIR)
             tftpd = threading.Thread(target = tftp_server.listen)
             tftpd.daemon = True
             tftpd.start()
@@ -253,7 +250,7 @@ def main():
             sys_logger.info('Starting HTTP server...')
 
             # setup the thread
-            http_server = http.HTTPD(mode_debug = do_debug('http'), mode_verbose = do_debug('http'), logger = http_logger)
+            http_server = http.HTTPD(mode_debug = do_debug('http'), mode_verbose = do_debug('http'), logger = http_logger, netboot_directory = args.NETBOOT_DIR)
             httpd = threading.Thread(target = http_server.listen)
             httpd.daemon = True
             httpd.start()


### PR DESCRIPTION
Removed the `os.chroot()` path traversal protection hack, and replaced it with detecting path traversal outside the `netboot_directory` given.

I've verified that access to files in `HTTPD` and `TFTPD` both work, and that I've been unable to escape `netboot_directory`. I don't have a setup where I'm able to test `NBD`, but from looking at the code, I'm not sure how it could've worked in the past without having the `block_device` be inside and relative to `netboot_directory`.