### PR TITLE
Multiple Bug Fixes

### DIFF
--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -25,7 +25,7 @@ class DHCPD:
     def __init__(self, **server_settings):
 
         self.ip = server_settings.get('ip', '192.168.2.2')
-        self.port = server_settings.get('port', 67)
+        self.port = int(server_settings.get('port', 67))
         self.offer_from = server_settings.get('offer_from', '192.168.2.100')
         self.offer_to = server_settings.get('offer_to', '192.168.2.150')
         self.subnet_mask = server_settings.get('subnet_mask', '255.255.255.0')

--- a/pypxe/http.py
+++ b/pypxe/http.py
@@ -19,7 +19,7 @@ class HTTPD:
     def __init__(self, **server_settings):
 
         self.ip = server_settings.get('ip', '0.0.0.0')
-        self.port = server_settings.get('port', 80)
+        self.port = int(server_settings.get('port', 80))
         self.netboot_directory = server_settings.get('netboot_directory', '.')
         self.mode_verbose = server_settings.get('mode_verbose', False) # verbose mode
         self.mode_debug = server_settings.get('mode_debug', False) # debug mode

--- a/pypxe/nbd/nbd.py
+++ b/pypxe/nbd/nbd.py
@@ -15,7 +15,7 @@ class NBD:
         self.in_mem = server_settings.get('in_mem', False)
         self.copy_to_ram = server_settings.get('copy_to_ram', False)
         self.ip = server_settings.get('ip', '0.0.0.0')
-        self.port = server_settings.get('port', 10809)
+        self.port = int(server_settings.get('port', 10809))
         self.mode_debug = server_settings.get('mode_debug', False) # debug mode
         self.mode_verbose = server_settings.get('mode_verbose', False) # debug mode
         self.logger =  server_settings.get('logger', None)

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -190,6 +190,10 @@ def main():
         if args.NBD_COW_IN_MEM or args.NBD_COPY_TO_RAM:
             sys_logger.warning('NBD cowinmem and copytoram can cause high RAM usage')
 
+        if args.NBD_COW and not args.NBD_WRITE:
+            # cow implies write
+            args.NBD_WRITE = True
+
         # make a list of running threads for each service
         running_services = []
 

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -271,7 +271,8 @@ def main():
                 port = args.NBD_PORT,
                 mode_debug = do_debug('nbd'),
                 mode_verbose = do_verbose('nbd'),
-                logger = nbd_logger)
+                logger = nbd_logger,
+                netboot_directory = args.NETBOOT_DIR)
             nbdd = threading.Thread(target = nbd_server.listen)
             nbdd.daemon = True
             nbdd.start()

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -272,10 +272,10 @@ def main():
                 mode_debug = do_debug('nbd'),
                 mode_verbose = do_verbose('nbd'),
                 logger = nbd_logger)
-            nbd = threading.Thread(target = nbd_server.listen)
-            nbd.daemon = True
-            nbd.start()
-            running_services.append(nbd)
+            nbdd = threading.Thread(target = nbd_server.listen)
+            nbdd.daemon = True
+            nbdd.start()
+            running_services.append(nbdd)
 
         sys_logger.info('PyPXE successfully initialized and running!')
 

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -244,7 +244,7 @@ class TFTPD:
     '''
     def __init__(self, **server_settings):
         self.ip = server_settings.get('ip', '0.0.0.0')
-        self.port = server_settings.get('port', 69)
+        self.port = int(server_settings.get('port', 69))
         self.netboot_directory = server_settings.get('netboot_directory', '.')
         self.mode_verbose = server_settings.get('mode_verbose', False) # verbose mode
         self.mode_debug = server_settings.get('mode_debug', False) # debug mode


### PR DESCRIPTION
* Fixed scope issue in `server.py`, causing a crash when nbd is used
* Cast port numbers to `int`, fixing CLI port options
* Normalize NBD block device path for when we're opening.
* Make `--nbd-cow` imply `--nbd-write`, as otherwise `--nbd-cow` does nothing and the client is still readonly.

Aplogies for multiple fixes in one PR, but they are all one liners or so, so I didn't think they warranted their own PRs, but they have their own commits.