### PR TITLE
tftp.py: do not include tsize in OACK if it was not in the request

### DIFF
--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -120,8 +120,9 @@ class Client:
         response = struct.pack("!H", 6)
         response += 'blksize' + chr(0)
         response += str(self.blksize) + chr(0)
-        response += 'tsize' + chr(0)
-        response += str(self.filesize) + chr(0)
+        if self.tsize:
+            response += 'tsize' + chr(0)
+            response += str(self.filesize) + chr(0)
         self.sock.sendto(response, self.address)
 
     def new_request(self):


### PR DESCRIPTION
Some clients will reject an OACK which has blksize and tsize if the
request had only blksize. This commit fixes this issue.
RFC2347 states that 'The server must not include in the OACK any option
which had not been specifically requested by the client'.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>