### PR TITLE
pypxe/tftp.py: set select timeout to None to reduce CPU usage

### DIFF
--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -268,7 +268,7 @@ class TFTPD:
         while True:
             # remove complete clients to select doesn't fail
             map(self.ongoing.remove, [client for client in self.ongoing if client.dead])
-            rlist, _, _ = select.select([self.sock] + [client.sock for client in self.ongoing if not client.dead], [], [], 0)
+            rlist, _, _ = select.select([self.sock] + [client.sock for client in self.ongoing if not client.dead], [], [], None)
             for sock in rlist:
                 if sock == self.sock:
                     # main socket, so new client


### PR DESCRIPTION
The TFTP server needlessly loops on the select call due to the zero
timeout value. Replace it with None to specify an infinite timeout.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>