### PR TITLE
pypxe/dhcp.py: avoid exception when leases have no options

### DIFF
--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -266,7 +266,7 @@ class DHCPD:
         if not filename:
             if not self.ipxe or not self.leases[client_mac]['ipxe']:
                 # http://www.syslinux.org/wiki/index.php/PXELINUX#UEFI
-                if 93 in self.leases[client_mac]['options'] and not self.force_file_name:
+                if 'options' in self.leases[client_mac] and 93 in self.leases[client_mac]['options'] and not self.force_file_name:
                     [arch] = struct.unpack("!H", self.leases[client_mac]['options'][93][0])
                     filename = {0: 'pxelinux.0', # BIOS/default
                                 6: 'syslinux.efi32', # EFI IA32


### PR DESCRIPTION
Fixes the following crash:

Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "pypxe/dhcp.py", line 355, in listen
    self.dhcp_offer(message)
  File "pypxe/dhcp.py", line 293, in dhcp_offer
    options_response = self.craft_options(2, client_mac) # DHCPOFFER
  File "pypxe/dhcp.py", line 269, in craft_options
    if 93 in self.leases[client_mac]['options'] and not self.force_file_name:
KeyError: 'options'

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>