### PR TITLE
pypxe/tftp.py: set select timeout to 1 to reduce CPU usage

### DIFF
--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -268,7 +268,7 @@ class TFTPD:
         while True:
             # remove complete clients to select doesn't fail
             map(self.ongoing.remove, [client for client in self.ongoing if client.dead])
-            rlist, _, _ = select.select([self.sock] + [client.sock for client in self.ongoing if not client.dead], [], [], 0)
+            rlist, _, _ = select.select([self.sock] + [client.sock for client in self.ongoing if not client.dead], [], [], 1)
             for sock in rlist:
                 if sock == self.sock:
                     # main socket, so new client


### PR DESCRIPTION
The TFTP server needlessly loops on the select call due to the zero
timeout value. Set timeout to 1s to conserve CPU while still allowing
re-transmission in case an ACK is lost.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>