### PR TITLE
Implement Logger.getChild ourselves

### DIFF
--- a/pypxe/helpers.py
+++ b/pypxe/helpers.py
@@ -5,6 +5,7 @@ This file contains helper functions used throughout the PyPXE services
 '''
 
 import os.path
+import logging
 
 class PathTraversalException(Exception):
     pass
@@ -33,3 +34,18 @@ def normalize_path(base, filename):
     if normalized.startswith(os.path.join(abs_path, '')):
         return normalized
     raise PathTraversalException('Path Traversal detected')
+
+def get_child_logger(logger, name):
+    '''
+        Get a descendant of an existing Logger.
+
+        This only exists because logger.getChild isn't in Python 2.6.
+
+        Args:
+            logger (Logger): Parent logger to create descendant of
+            name (str): Name to append to parent's name
+
+        Returns:
+            Logger: new Logger with `name` appended
+    '''
+    return logging.getLogger("{0}.{1}".format(logger.name, name))

--- a/pypxe/nbd/writes.py
+++ b/pypxe/nbd/writes.py
@@ -1,4 +1,5 @@
 import io
+from .. import helpers
 
 class COW:
     def basepages(self, offset, length):
@@ -86,7 +87,7 @@ class DiskCOW(COW):
         self.addr = addr
         self.imagefd = imagefd
         self.seek_lock = seek_lock
-        self.logger = logger.getChild('FS')
+        self.logger = helpers.get_child_logger(logger, 'FS')
         self.logger.info('Copy-On-Write for {addr} in PyPXE_NBD_COW_{addr[0]}_{addr[1]}'.format(addr = addr))
 
         # never want readonly cow, also definately creating file
@@ -101,7 +102,7 @@ class MemCOW(COW):
         self.addr = addr
         self.imagefd = imagefd
         self.seek_lock = seek_lock
-        self.logger = logger.getChild('FS')
+        self.logger = helpers.get_child_logger(logger, 'FS')
         self.logger.info('Copy-On-Write for {0} in Memory'.format(addr))
 
         # BytesIO looks exactly the same as a file, perfect for in memory disk
@@ -116,7 +117,7 @@ class RW:
         self.addr = addr
         self.seek_lock = seek_lock
         self.imagefd = imagefd
-        self.logger = logger.getChild('FS')
+        self.logger = helpers.get_child_logger(logger, 'FS')
         self.logger.debug('File for {0}'.format(addr))
 
     def read(self, offset, length):

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -16,7 +16,7 @@ from pypxe import tftp # PyPXE TFTP service
 from pypxe import dhcp # PyPXE DHCP service
 from pypxe import http # PyPXE HTTP service
 from pypxe import nbd  # PyPXE NBD service
-
+from pypxe import helpers
 args = None
 # default settings
 SETTINGS = {'NETBOOT_DIR':'netboot',
@@ -202,7 +202,7 @@ def main():
         if args.USE_TFTP:
 
             # setup TFTP logger
-            tftp_logger = sys_logger.getChild('TFTP')
+            tftp_logger = helpers.get_child_logger(sys_logger, 'TFTP')
             sys_logger.info('Starting TFTP server...')
 
             # setup the thread
@@ -216,7 +216,7 @@ def main():
         if args.USE_DHCP:
 
             # setup DHCP logger
-            dhcp_logger = sys_logger.getChild('DHCP')
+            dhcp_logger = helpers.get_child_logger(sys_logger, 'DHCP')
             if args.DHCP_MODE_PROXY:
                 sys_logger.info('Starting DHCP server in ProxyDHCP mode...')
             else:
@@ -252,7 +252,7 @@ def main():
         if args.USE_HTTP:
 
             # setup HTTP logger
-            http_logger = sys_logger.getChild('HTTP')
+            http_logger = helpers.get_child_logger(sys_logger, 'HTTP')
             sys_logger.info('Starting HTTP server...')
 
             # setup the thread
@@ -265,7 +265,7 @@ def main():
         # configure/start NBD server
         if args.NBD_BLOCK_DEVICE:
             # setup NBD logger
-            nbd_logger = sys_logger.getChild('NBD')
+            nbd_logger = helpers.get_child_logger(sys_logger, 'NBD')
             sys_logger.info('Starting NBD server...')
             nbd_server = nbd.NBD(
                 block_device = args.NBD_BLOCK_DEVICE,

--- a/pypxe/tftp.py
+++ b/pypxe/tftp.py
@@ -24,7 +24,7 @@ class Client:
         self.timeout = parent.timeout
         self.ip = parent.ip
         self.message, self.address = mainsock.recvfrom(1024)
-        self.logger = parent.logger.getChild('Client.{0}'.format(self.address))
+        self.logger = helpers.get_child_logger(parent.logger, 'Client.{0}'.format(self.address))
         self.netboot_directory = parent.netboot_directory
         self.logger.debug('Recieving request...')
         self.retries = self.default_retries


### PR DESCRIPTION
Implement Logger.getChild ourselves since that doesn't exist in Python 2.6.

Resolves psychomario/PyPXE#136