### PR TITLE
Expose TFTP bind IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ The following are arguments that can be passed to `pypxe.server` when running fr
 |__`--dhcp-fileserver-ip DHCP_FILESERVER_IP`__|Specify DHCP file server IP address|`192.168.2.2`|
 |__`--dhcp-whitelist`__|Only serve clients specified in the static lease file (`--static-config`)|`False`|
 
+##### TFTP Service Arguments
+
+|Argument|Description|Default|
+|---|---|---|
+|__`--tftp-server-ip TFTP_SERVER_IP`__|Specify TFTP server IP address|`0.0.0.0`|
 
 ##### File Name/Directory Arguments
 

--- a/example_cfg.json
+++ b/example_cfg.json
@@ -25,6 +25,7 @@
     "STATIC_CONFIG": "", 
     "SYSLOG_PORT": 514, 
     "SYSLOG_SERVER": null, 
+    "TFTP_SERVER_IP": "192.168.2.2", 
     "USE_DHCP": true, 
     "USE_HTTP": false, 
     "USE_IPXE": false, 

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -35,6 +35,7 @@ SETTINGS = {'NETBOOT_DIR':'netboot',
             'STATIC_CONFIG':'',
             'SYSLOG_SERVER':None,
             'SYSLOG_PORT':514,
+            'TFTP_SERVER_IP':'0.0.0.0',
             'USE_IPXE':False,
             'USE_HTTP':False,
             'USE_TFTP':True,
@@ -107,6 +108,11 @@ def parse_cli_arguments():
     nbd_group.add_argument('--nbd-copy-to-ram', action = 'store_true', dest = 'NBD_COPY_TO_RAM', help = 'Copy the NBD device to memory before serving clients', default = SETTINGS['NBD_COPY_TO_RAM'])
     nbd_group.add_argument('--nbd-server', action = 'store', dest = 'NBD_SERVER_IP', help = 'NBD Server IP', default = SETTINGS['NBD_SERVER_IP'])
     nbd_group.add_argument('--nbd-port', action = 'store', dest = 'NBD_PORT', help = 'NBD Server Port', default = SETTINGS['NBD_PORT'])
+
+    # TFTP server arguments
+    tftp_group = parser.add_argument_group(title = 'TFTP', description = 'Arguments relevant to the TFTP server')
+    tftp_group.add_argument('--tftp-server-ip', action = 'store', dest = 'TFTP_SERVER_IP', help = 'TFTP Server IP', default = SETTINGS['TFTP_SERVER_IP'])
+
 
     return parser.parse_args()
 
@@ -224,7 +230,12 @@ def main():
             sys_logger.info('Starting TFTP server...')
 
             # setup the thread
-            tftp_server = tftp.TFTPD(mode_debug = do_debug('tftp'), mode_verbose = do_verbose('tftp'), logger = tftp_logger, netboot_directory = args.NETBOOT_DIR)
+            tftp_server = tftp.TFTPD(
+                mode_debug = do_debug('tftp'),
+                mode_verbose = do_verbose('tftp'),
+                logger = tftp_logger,
+                netboot_directory = args.NETBOOT_DIR,
+                ip = args.TFTP_SERVER_IP)
             tftpd = threading.Thread(target = tftp_server.listen)
             tftpd.daemon = True
             tftpd.start()

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -134,7 +134,8 @@ def main():
                 settings = args.__dict__
                 del settings['DUMP_CONFIG']
                 del settings['DUMP_CONFIG_MERGED']
-            print json.dumps(SETTINGS, sort_keys=True, indent=4)
+                del settings['JSON_CONFIG']
+            print json.dumps(settings, sort_keys=True, indent=4)
             sys.exit()
 
         if args.JSON_CONFIG: # load from configuration file if specified

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if version_info[0] == 2 and version_info[1] < 7:
     deps.append('argparse')
 
 setup(name='PyPXE',
-      version='1.7.1',
+      version='1.7.2',
       description='Pure Python2 PXE (DHCP-(Proxy)/TFTP/HTTP/NBD) Server',
       url='https://github.com/psychomario/PyPXE',
       license='MIT',


### PR DESCRIPTION
@Apachez- asked to have the TFTP server bind address exposed in psychomario/PyPXE#151. This does that as `--tftp-server-ip` on the command line, and `TFTP_SERVER_IP` in the config, following the same conventions as similar options for the DHCP server.