### PR TITLE
Python3 lowpass changes, zero impact to Python 2.6+

### DIFF
--- a/pypxe/dhcp.py
+++ b/pypxe/dhcp.py
@@ -122,7 +122,9 @@ class DHCPD:
                     import_safe[packed_mac] = imported[lease]
                 self.leases.update(import_safe)
                 self.logger.info('Loaded leases from {0}'.format(self.save_leases_file))
-            except IOError, ValueError:
+            except IOError:
+                pass
+            except ValueError:
                 pass
 
         signal.signal(signal.SIGINT, self.export_leases)

--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import threading
+import io
 import os
 import sys
 import json
@@ -141,12 +142,12 @@ def main():
                 del settings['DUMP_CONFIG']
                 del settings['DUMP_CONFIG_MERGED']
                 del settings['JSON_CONFIG']
-            print json.dumps(settings, sort_keys=True, indent=4)
+            print(json.dumps(settings, sort_keys=True, indent=4))
             sys.exit()
 
         if args.JSON_CONFIG: # load from configuration file if specified
             try:
-                config_file = open(args.JSON_CONFIG, 'rb')
+                config_file = io.open(args.JSON_CONFIG, 'r')
             except IOError:
                 sys.exit('Failed to open {0}'.format(args.JSON_CONFIG))
             try:
@@ -162,14 +163,14 @@ def main():
 
         # warn the user that they are starting PyPXE as non-root user
         if os.getuid() != 0:
-            print >> sys.stderr, '\nWARNING: Not root. Servers will probably fail to bind.\n'
+            print(sys.stderr, '\nWARNING: Not root. Servers will probably fail to bind.\n')
 
 
         # ideally this would be in dhcp itself, but the chroot below *probably*
         # breaks the ability to open the config file.
         if args.STATIC_CONFIG:
             try:
-                static_config = open(args.STATIC_CONFIG, 'rb')
+                static_config = io.open(args.STATIC_CONFIG, 'r')
             except IOError:
                 sys.exit("Failed to open {0}".format(args.STATIC_CONFIG))
             try:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ deps = []
 
 # Python 3 unsupported
 if version_info >= (3,):
-    print "Sorry, PyPXE doesn't support Python 3."
+    print("Sorry, PyPXE doesn't support Python 3.")
     exit(1)
 
 # require argparse on Python <2.7


### PR DESCRIPTION
#147 broken apart with just the simple Python3 changes.

1. setup.py will display the error now vs just failing
2. exception splitting in dhcp.py works across Python versions
3. file open changes, using io.open works across Python versions
4. Print is a function, no future import needed. https://docs.python.org/2.6/library/functions.html#print

Disclaimer, I did the proof of concept for Ansible and Python3, not my first roller coaster.

will note the getuid vs geteuid in another PR