### PR TITLE
Using Effective UID and warning for Python 2 and 3

### DIFF
--- a/pypxe/server.py
+++ b/pypxe/server.py
@@ -167,8 +167,8 @@ def main():
             args = parse_cli_arguments() # re-parse, CLI options take precedence
 
         # warn the user that they are starting PyPXE as non-root user
-        if os.getuid() != 0:
-            print(sys.stderr, '\nWARNING: Not root. Servers will probably fail to bind.\n')
+        if os.geteuid() != 0:
+            print("\nWARNING: Not root. Servers will probably fail to bind.\n")
 
 
         # ideally this would be in dhcp itself, but the chroot below *probably*


### PR DESCRIPTION
Using Effective UID in the case that user has been granted access to operate as UID 0. Currently there is a warning and then a failure to bind to port for TFTP which I can note in an issue. Without TFTP running it starts fine.

$ PYTHONPATH='/home/user/sandbox/PyPXE' python pypxe/server.py --no-tftp

WARNING: Not root. Servers will probably fail to bind.

2017-06-29 12:20:25,997 [INFO] PyPXE PyPXE successfully initialized and running!
^C
Shutting down PyPXE...

$ PYTHONPATH='/home/user/sandbox/PyPXE' python pypxe/server.py

WARNING: Not root. Servers will probably fail to bind.

2017-06-29 12:20:33,387 [INFO] PyPXE Starting TFTP server...
Traceback (most recent call last):
File "pypxe/server.py", line 325, in 
main()
File "pypxe/server.py", line 238, in main
ip = args.TFTP_SERVER_IP)
File "/home/user/sandbox/PyPXE/pypxe/tftp.py", line 243, in init
self.sock.bind((self.ip, self.port))
File "/usr/lib/python2.7/socket.py", line 228, in meth
return getattr(self._sock,name)(*args)
socket.error: [Errno 13] Permission denied
$

And with Python 3 for bonus points
$ PYTHONPATH='/home/user/sandbox/PyPXE' python3 pypxe/server.py --no-tftp

WARNING: Not root. Servers will probably fail to bind.

2017-06-29 12:49:51,815 [INFO] PyPXE PyPXE successfully initialized and running!
^C
Shutting down PyPXE...
